### PR TITLE
[Feat/log in] 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ captures/
 *.keystore
 
 # Google Services (e.g. APIs or Firebase)
-# google-services.json
+google-services.json
 
 # Android Patch
 gen-external-apklibs

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,13 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("com.google.gms.google-services")
 }
+
+val properties = Properties()
+properties.load(rootProject.file("local.properties").inputStream())
 
 android {
     compileSdkVersion(33)
@@ -13,13 +19,18 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        buildConfigField("String", "GOOGLE_CLIENT_ID", properties.getProperty("google_client_id"))
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 
@@ -43,6 +54,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("com.google.android.gms:play-services-base:18.2.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
@@ -50,6 +62,15 @@ dependencies {
     //Jetpack Navigation Graph 관련
     implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")
     implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
+    //Firebase Bom 관련
+    implementation(platform("com.google.firebase:firebase-bom:32.0.0"))
+    //Firebase analytics 관련
+    implementation("com.google.firebase:firebase-analytics-ktx")
+    //Firebase auth 관련
+    implementation("com.google.firebase:firebase-auth-ktx:22.0.0")
     //Google Play Services의 base 관련
     implementation("com.google.android.gms:play-services-base:18.2.0")
+    //Google Play Services의 auth 관련
+    implementation("com.google.android.gms:play-services-auth:20.5.0")
+
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
+    id ("androidx.navigation.safeargs.kotlin")
 }
 
 val properties = Properties()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,5 +73,6 @@ dependencies {
     implementation("com.google.android.gms:play-services-base:18.2.0")
     //Google Play Services의 auth 관련
     implementation("com.google.android.gms:play-services-auth:20.5.0")
-
+    //Fragment ktx(ViewModel 초기화) 관련
+    implementation ("androidx.fragment:fragment-ktx:1.5.7")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.mbj.ssassamarket">
 
     <application
+        android:name=".SsaSsaMarketApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
@@ -1,0 +1,16 @@
+package com.mbj.ssassamarket
+
+import android.app.Application
+import com.mbj.ssassamarket.util.PreferenceManager
+
+class SsaSsaMarketApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        preferenceManager = PreferenceManager(this)
+    }
+
+    companion object {
+        lateinit var preferenceManager: PreferenceManager
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/ui/BaseFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/BaseFragment.kt
@@ -4,27 +4,31 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
-import androidx.viewbinding.ViewBinding
 
-abstract class BaseFragment<VB : ViewBinding> : Fragment() {
+open class BaseFragment : Fragment() {
 
-    private var _binding: VB? = null
-    private val binding: VB
-        get() = _binding!!
-
-    abstract fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): VB
+    var _binding: ViewDataBinding? = null
+    open val binding get() = _binding!!
+    open val layoutId: Int = 0
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View {
-        _binding = inflateBinding(inflater, container)
+    ): View? {
+        _binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
         return binding.root
     }
 
-    final override fun onDestroyView() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+    }
+
+    override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -11,6 +11,7 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
@@ -37,6 +38,8 @@ class LogInFragment : BaseFragment() {
     private lateinit var googleOneTabSignInLauncher: ActivityResultLauncher<IntentSenderRequest>
     private lateinit var googleSignInLauncherIdentity: ActivityResultLauncher<IntentSenderRequest>
 
+    private val viewModel: LogInViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeSignInClients()
@@ -44,11 +47,12 @@ class LogInFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        initializeAutoLoginPreference()
-        setupAutoLoginCheckboxListener()
+        binding.viewModel = viewModel
         binding.logInBt.setOnClickListener {
             signInWithGoogleOneTap()
+        }
+        viewModel.autoLoginEnabled.observe(viewLifecycleOwner) { isChecked ->
+            SsaSsaMarketApplication.preferenceManager.putBoolean(AUTO_LOGIN, isChecked)
         }
     }
 
@@ -182,21 +186,6 @@ class LogInFragment : BaseFragment() {
     private fun navigateToHomeFragment() {
         val action = LogInFragmentDirections.actionLogInFragmentToSettingNicknameFragment()
         findNavController().navigate(action)
-    }
-
-    private fun initializeAutoLoginPreference() {
-        with(SsaSsaMarketApplication.preferenceManager) {
-            val autoLoginEnabled = getBoolean(AUTO_LOGIN, false)
-            binding.autoLogInCb.isChecked = autoLoginEnabled
-        }
-    }
-
-    private fun setupAutoLoginCheckboxListener() {
-        with(SsaSsaMarketApplication.preferenceManager) {
-            binding.autoLogInCb.setOnCheckedChangeListener { _, isChecked ->
-                putBoolean(AUTO_LOGIN, isChecked)
-            }
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -1,16 +1,190 @@
 package com.mbj.ssassamarket.ui.login
 
-import com.mbj.ssassamarket.ui.BaseFragment
+import android.app.Activity
+import android.content.Intent
+import android.content.IntentSender
+import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
+import com.mbj.ssassamarket.ui.BaseFragment
+import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.gms.auth.api.identity.BeginSignInRequest
+import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.auth.api.identity.SignInClient
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.GoogleAuthProvider
+import com.mbj.ssassamarket.BuildConfig
+import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.databinding.FragmentLogInBinding
 
 class LogInFragment : BaseFragment<FragmentLogInBinding>() {
 
     private lateinit var binding: FragmentLogInBinding
 
+    private lateinit var oneTapClient: SignInClient
+    private lateinit var auth: FirebaseAuth
+
+    private lateinit var googleOneTabSignInLauncher: ActivityResultLauncher<IntentSenderRequest>
+    private lateinit var googleSignInLauncherIdentity: ActivityResultLauncher<IntentSenderRequest>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initializeSignInClients()
+    }
+
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLogInBinding {
         binding = FragmentLogInBinding.inflate(inflater, container, false)
         return binding
     }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.logInBt.setOnClickListener {
+            signInWithGoogleOneTap()
+        }
+    }
+
+    private fun initializeSignInClients() {
+        oneTapClient = Identity.getSignInClient(requireContext())
+        auth = FirebaseAuth.getInstance()
+
+        googleOneTabSignInLauncher = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            handleGoogleOneTabSignInResult(result.resultCode, result.data)
+        }
+        googleSignInLauncherIdentity = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            handleGoogleSignInIdentityResult(result.resultCode, result.data)
+        }
+    }
+
+    private fun handleGoogleOneTabSignInResult(resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_OK) {
+            val intent = data
+            val credential = oneTapClient.getSignInCredentialFromIntent(intent)
+            val googleIdToken = credential.googleIdToken
+            if (googleIdToken != null) {
+                firebaseAuthWithGoogle(googleIdToken)
+            } else {
+                Toast.makeText(requireContext(), R.string.log_in_failure, Toast.LENGTH_SHORT).show()
+            }
+        } else {
+            Toast.makeText(requireContext(), R.string.log_in_cancle, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun handleGoogleSignInIdentityResult(resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_OK) {
+            try {
+                val credential = Identity.getSignInClient(requireActivity())
+                    .getSignInCredentialFromIntent(data)
+                val googleIdToken = credential.googleIdToken
+                if (googleIdToken != null) {
+                    firebaseAuthWithGoogle(googleIdToken)
+                } else {
+                    Toast.makeText(requireContext(), R.string.log_in_failure, Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Google Sign-In failed", e)
+            }
+        } else {
+            Toast.makeText(requireContext(), R.string.log_in_cancle, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun signInWithGoogleOneTap() {
+        oneTapClient.beginSignIn(getGoogleOneTabSignInOptions())
+            .addOnSuccessListener(requireActivity()) { result ->
+                val intentSenderRequest =
+                    IntentSenderRequest.Builder(result.pendingIntent.intentSender).build()
+                googleOneTabSignInLauncher.launch(intentSenderRequest)
+            }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to begin one tab sign-in", e)
+                handleOneTabException(e)
+            }
+    }
+
+    private fun getGoogleOneTabSignInOptions(): BeginSignInRequest {
+        return BeginSignInRequest.builder()
+            .setGoogleIdTokenRequestOptions(
+                BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
+                    .setSupported(true)
+                    .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
+                    .setFilterByAuthorizedAccounts(true)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun signInWithGoogleByIdentity() {
+        val request = GetSignInIntentRequest.builder()
+            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
+            .build()
+
+        Identity.getSignInClient(requireActivity())
+            .getSignInIntent(request)
+            .addOnSuccessListener { result ->
+                try {
+                    googleSignInLauncherIdentity.launch(
+                        IntentSenderRequest.Builder(result.intentSender).build()
+                    )
+                } catch (e: IntentSender.SendIntentException) {
+                    Log.e(TAG, "Google Sign-in failed")
+                }
+            }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Google Sign-in failed", e)
+            }
+    }
+
+    private fun handleOneTabException(exception: Exception) {
+        when (exception) {
+
+            is ApiException -> {
+                Log.e(TAG, "Failed to begin one tab sign-in(ApiException)", exception)
+                when (exception.statusCode) {
+                    CommonStatusCodes.CANCELED ->  signInWithGoogleByIdentity()
+                    else ->  signInWithGoogleByIdentity()
+                }
+            }
+            else -> {
+                Log.e(TAG, "Failed to begin one tab sign-in(Exception)", exception)
+                signInWithGoogleByIdentity()
+            }
+        }
+    }
+
+    private fun firebaseAuthWithGoogle(idToken: String?) {
+        val authCredential = GoogleAuthProvider.getCredential(idToken, null)
+        auth.signInWithCredential(authCredential)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    Toast.makeText(requireContext(), getString(R.string.log_in_success), Toast.LENGTH_SHORT).show()
+                } else {
+                    Log.e(TAG, "Firebase authentication failed", task.exception)
+                    when (task.exception?.message) {
+                        FIREBASE_AUTH_EXCEPTION_NETWORK -> Toast.makeText(requireContext(), R.string.log_in_error_network, Toast.LENGTH_SHORT).show()
+                        FIREBASE_AUTH_EXCEPTION_NETWORK2 -> Toast.makeText(requireContext(), R.string.log_in_error_network, Toast.LENGTH_SHORT).show()
+                        else -> Toast.makeText(requireContext(), R.string.log_in_error_firebase, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+    }
+
+    companion object {
+        private const val TAG = "LogInFragment"
+        private const val FIREBASE_AUTH_EXCEPTION_NETWORK =
+            "A network error (such as timeout, interrupted connection or unreachable host) has occurred." //네트워크 오류로 인해 Firebase 인증 실패 오류 메세지
+        private const val FIREBASE_AUTH_EXCEPTION_NETWORK2 =
+            "com.google.firebase.FirebaseNetworkException: A network error (such as timeout, interrupted connection or unreachable host)" //네트워크 오류로 인해 Firebase 인증 실패 오류 메세지
+    }
 }
+

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -11,6 +11,7 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
 import com.google.android.gms.auth.api.identity.Identity
@@ -161,6 +162,7 @@ class LogInFragment : BaseFragment() {
         auth.signInWithCredential(authCredential)
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
+                    navigateToHomeFragment()
                     Toast.makeText(requireContext(), getString(R.string.log_in_success), Toast.LENGTH_SHORT).show()
                 } else {
                     Log.e(TAG, "Firebase authentication failed", task.exception)
@@ -171,6 +173,11 @@ class LogInFragment : BaseFragment() {
                     }
                 }
             }
+    }
+
+    private fun navigateToHomeFragment() {
+        val action = LogInFragmentDirections.actionLogInFragmentToSettingNicknameFragment()
+        findNavController().navigate(action)
     }
 
     companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -22,7 +22,9 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.mbj.ssassamarket.BuildConfig
 import com.mbj.ssassamarket.R
+import com.mbj.ssassamarket.SsaSsaMarketApplication
 import com.mbj.ssassamarket.databinding.FragmentLogInBinding
+import com.mbj.ssassamarket.util.Constants.AUTO_LOGIN
 
 class LogInFragment : BaseFragment() {
 
@@ -43,6 +45,8 @@ class LogInFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initializeAutoLoginPreference()
+        setupAutoLoginCheckboxListener()
         binding.logInBt.setOnClickListener {
             signInWithGoogleOneTap()
         }
@@ -178,6 +182,21 @@ class LogInFragment : BaseFragment() {
     private fun navigateToHomeFragment() {
         val action = LogInFragmentDirections.actionLogInFragmentToSettingNicknameFragment()
         findNavController().navigate(action)
+    }
+
+    private fun initializeAutoLoginPreference() {
+        with(SsaSsaMarketApplication.preferenceManager) {
+            val autoLoginEnabled = getBoolean(AUTO_LOGIN, false)
+            binding.autoLogInCb.isChecked = autoLoginEnabled
+        }
+    }
+
+    private fun setupAutoLoginCheckboxListener() {
+        with(SsaSsaMarketApplication.preferenceManager) {
+            binding.autoLogInCb.setOnCheckedChangeListener { _, isChecked ->
+                putBoolean(AUTO_LOGIN, isChecked)
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -5,10 +5,8 @@ import android.content.Intent
 import android.content.IntentSender
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import com.mbj.ssassamarket.ui.BaseFragment
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
@@ -25,9 +23,10 @@ import com.mbj.ssassamarket.BuildConfig
 import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.databinding.FragmentLogInBinding
 
-class LogInFragment : BaseFragment<FragmentLogInBinding>() {
+class LogInFragment : BaseFragment() {
 
-    private lateinit var binding: FragmentLogInBinding
+    override val binding get() = _binding as FragmentLogInBinding
+    override val layoutId: Int get() = R.layout.fragment_log_in
 
     private lateinit var oneTapClient: SignInClient
     private lateinit var auth: FirebaseAuth
@@ -38,11 +37,6 @@ class LogInFragment : BaseFragment<FragmentLogInBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeSignInClients()
-    }
-
-    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLogInBinding {
-        binding = FragmentLogInBinding.inflate(inflater, container, false)
-        return binding
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
@@ -1,0 +1,10 @@
+package com.mbj.ssassamarket.ui.login
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.mbj.ssassamarket.SsaSsaMarketApplication
+import com.mbj.ssassamarket.util.Constants.AUTO_LOGIN
+
+class LogInViewModel() : ViewModel() {
+    var autoLoginEnabled = MutableLiveData<Boolean>(SsaSsaMarketApplication.preferenceManager.getBoolean(AUTO_LOGIN, false))
+}

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -1,0 +1,11 @@
+package com.mbj.ssassamarket.ui.settingnickname
+
+import com.mbj.ssassamarket.R
+import com.mbj.ssassamarket.databinding.FragmentSettingNicknameBinding
+import com.mbj.ssassamarket.ui.BaseFragment
+
+class SettingNicknameFragment : BaseFragment() {
+
+    override val binding get() = _binding as FragmentSettingNicknameBinding
+    override val layoutId: Int get() = R.layout.fragment_setting_nickname
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
@@ -1,0 +1,5 @@
+package com.mbj.ssassamarket.util
+
+object Constants {
+    const val AUTO_LOGIN = "autoLogin"
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/PreferenceManager.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/PreferenceManager.kt
@@ -1,0 +1,22 @@
+package com.mbj.ssassamarket.util
+
+import android.content.Context
+
+class PreferenceManager(context: Context) {
+
+    private val sharedPreferences = context.getSharedPreferences(
+        "com.mbj.ssassamarket.PREFERENCE_KEY",
+        Context.MODE_PRIVATE
+    )
+
+    fun putBoolean(key: String, value: Boolean) {
+        with(sharedPreferences.edit()) {
+            putBoolean(key, value)
+            apply()
+        }
+    }
+
+    fun getBoolean(key: String, defValue: Boolean): Boolean {
+        return sharedPreferences.getBoolean(key, defValue) ?: defValue
+    }
+}

--- a/app/src/main/res/layout/fragment_log_in.xml
+++ b/app/src/main/res/layout/fragment_log_in.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <variable
+            name="viewModel"
+            type="com.mbj.ssassamarket.ui.login.LogInViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -37,7 +39,8 @@
             android:buttonTint="@color/black"
             app:layout_constraintEnd_toStartOf="@+id/auto_log_in_tv"
             app:layout_constraintStart_toEndOf="@id/log_in_bt"
-            app:layout_constraintTop_toBottomOf="@id/log_in_bt" />
+            app:layout_constraintTop_toBottomOf="@id/log_in_bt"
+            android:checked="@={viewModel.autoLoginEnabled}"/>
 
         <TextView
             android:id="@+id/auto_log_in_tv"

--- a/app/src/main/res/layout/fragment_log_in.xml
+++ b/app/src/main/res/layout/fragment_log_in.xml
@@ -1,61 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.login.LogInFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <ImageView
-        android:id="@+id/log_in_logo_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@mipmap/login_logo"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/guideline_horizontal_20" />
+    <data>
 
-    <com.google.android.gms.common.SignInButton
-        android:id="@+id/log_in_bt"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:buttonSize="wide"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/guideline_horizontal_50" />
+    </data>
 
-    <CheckBox
-        android:id="@+id/auto_log_in_cb"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:buttonTint="@color/black"
-        app:layout_constraintEnd_toStartOf="@+id/auto_log_in_tv"
-        app:layout_constraintStart_toEndOf="@id/log_in_bt"
-        app:layout_constraintTop_toBottomOf="@id/log_in_bt" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.login.LogInFragment">
 
-    <TextView
-        android:id="@+id/auto_log_in_tv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/auto_log_in_tv"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@+id/auto_log_in_cb"
-        app:layout_constraintEnd_toStartOf="@id/log_in_bt"
-        app:layout_constraintStart_toEndOf="@+id/auto_log_in_cb"
-        app:layout_constraintTop_toTopOf="@+id/auto_log_in_cb" />
+        <ImageView
+            android:id="@+id/log_in_logo_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@mipmap/login_logo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal_20" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_horizontal_20"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.2" />
+        <com.google.android.gms.common.SignInButton
+            android:id="@+id/log_in_bt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:buttonSize="wide"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/guideline_horizontal_50" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_horizontal_50"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.50" />
+        <CheckBox
+            android:id="@+id/auto_log_in_cb"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:buttonTint="@color/black"
+            app:layout_constraintEnd_toStartOf="@+id/auto_log_in_tv"
+            app:layout_constraintStart_toEndOf="@id/log_in_bt"
+            app:layout_constraintTop_toBottomOf="@id/log_in_bt" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/auto_log_in_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/auto_log_in_tv"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@+id/auto_log_in_cb"
+            app:layout_constraintEnd_toStartOf="@id/log_in_bt"
+            app:layout_constraintStart_toEndOf="@+id/auto_log_in_cb"
+            app:layout_constraintTop_toTopOf="@+id/auto_log_in_cb" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal_20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.2" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal_50"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.50" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_setting_nickname.xml
+++ b/app/src/main/res/layout/fragment_setting_nickname.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.settingnickname.SettingNicknameFragment">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -9,5 +9,15 @@
         android:id="@+id/logInFragment"
         android:name="com.mbj.ssassamarket.ui.login.LogInFragment"
         android:label="fragment_log_in"
-        tools:layout="@layout/fragment_log_in" />
+        tools:layout="@layout/fragment_log_in" >
+        <action
+            android:id="@+id/action_logInFragment_to_settingNicknameFragment"
+            app:destination="@id/settingNicknameFragment"
+            app:popUpTo="@id/logInFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/settingNicknameFragment"
+        android:name="com.mbj.ssassamarket.ui.settingnickname.SettingNicknameFragment"
+        android:label="SettingNicknameFragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="app_name">SsaSsaMarket</string>
     <string name="auto_log_in_tv">자동 로그인</string>
+    <string name="log_in_cancle">로그인 취소</string>
+    <string name="log_in_failure">로그인 실패</string>
+    <string name="log_in_error_network">네트워크 오류</string>
+    <string name="log_in_success">로그인에 성공하셨습니다.</string>
+    <string name="log_in_error_firebase">문의글을 남겨주세요</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        classpath("com.google.gms:google-services:4.3.15")
+    }
+}
+
 plugins {
     id("com.android.application") version "7.3.1" apply false
     id("com.android.library") version "7.3.1" apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 buildscript {
     dependencies {
         classpath("com.google.gms:google-services:4.3.15")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3")
     }
 }
 


### PR DESCRIPTION
## 1. 구글 로그인 구현
1-1. 기본적으로 Google One Tab Sign-In 으로 로그인을 시도한다.
1-2. Google One Tab Sign-In 으로 로그인이 되지 않을때는 Google Sign-In(레거시)를 이용하여 로그인을 시도한다.
1-3. 로그인에 성공 시 SettingNicknameFragment로 이동하며 LogInFragment의 백스택을 제거한다.

## 2. 자동 로그인 정보 저장
2-1. 자동 로그인에 대한 Boolean 값을 SharedPreferece로 관리한다.
2-2. 자동 로그인에 대한 Boolean 값을 CheckBox와 Two-Way-DataBinding을 통해 관리한다. ( 자동 로그인에 대한 Booelan 값은 추후 스플래시 화면에서 사용한다. )

## To Do
1. Firebase Realtime Database를 만들고 user라는 객체 구조를 만들고 이 user라는 객체에 현재 로그인 uId의 값이 존재한다면 HomeFragment로 이동하고 존재하지 않는다면 SettingFragment로 이동하는 것을 구현한다.