### PR TITLE
[Feat/settingnickname-layout] 닉네임 설정 화면 레이아웃 구성

### DIFF
--- a/app/src/main/res/layout/fragment_setting_nickname.xml
+++ b/app/src/main/res/layout/fragment_setting_nickname.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -10,6 +11,70 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.settingnickname.SettingNicknameFragment">
+
+        <ImageView
+            android:id="@+id/setting_nickname_logo_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@mipmap/login_logo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal_20" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/setting_nickname_til"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            app:counterEnabled="true"
+            app:counterMaxLength="8"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/guideline_horizontal_50"
+            app:layout_constraintVertical_chainStyle="packed">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/setting_nickname_tiet"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/setting_nickname_hint"
+                android:imeOptions="actionNext"
+                android:inputType="text"
+                android:maxLength="8" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            style="@style/ButtonStyle"
+            android:layout_width="70dp"
+            android:layout_height="50dp"
+            android:text="@string/setting_nickname_register"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/setting_nickname_til"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal_65" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal_20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.2" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal_50"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.50" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal_65"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.65" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="orange_100">#1BFC5230</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="log_in_error_network">네트워크 오류</string>
     <string name="log_in_success">로그인에 성공하셨습니다.</string>
     <string name="log_in_error_firebase">문의글을 남겨주세요</string>
+    <string name="setting_nickname_register">등록</string>
+    <string name="setting_nickname_hint">닉네임을 입력해주세요.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,4 +13,10 @@
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="ButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="android:stateListAnimator">@null</item>
+        <item name="android:elevation">0dp</item>
+        <item name="android:backgroundTint">@color/orange_100</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 1. 닉네임 설정 화면 레이아웃을 구성함
1-1. 등록버튼의 그림자 효과가 제거하고, 단일 배경 색상으로 보이도록 Style을 설정함
1-2. 닉네임 입력 폼을 TextInputLayout, TextInputEditText 으로 구성하여 Error메세지와 메세지 입력 개수를 확인할 수 있도록 구성함