### PR TITLE
[Feat/settingnickname] 닉네임 설정 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
     id ("androidx.navigation.safeargs.kotlin")
+    id ("kotlin-kapt")
 }
 
 val properties = Properties()
@@ -78,6 +79,8 @@ dependencies {
 
     //Moshi(Json Converter) 관련
     implementation ("com.squareup.moshi:moshi:1.14.0")
+    implementation ("com.squareup.moshi:moshi-kotlin:1.9.3")
+    kapt ("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
 
     //OkHttp(네트워크 통신) 관련
     implementation ("com.squareup.okhttp3:okhttp:4.9.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         versionName = "1.0"
 
         buildConfigField("String", "GOOGLE_CLIENT_ID", properties.getProperty("google_client_id"))
+        buildConfigField("String", "FIREBASE_BASE_URL", properties.getProperty("firebase_base_url"))
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,4 +75,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-auth:20.5.0")
     //Fragment ktx(ViewModel 초기화) 관련
     implementation ("androidx.fragment:fragment-ktx:1.5.7")
+    //Moshi(Json Converter) 관련
+    implementation ("com.squareup.moshi:moshi:1.14.0")
+
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,6 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.android.gms:play-services-base:18.2.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
@@ -64,19 +63,27 @@ dependencies {
     //Jetpack Navigation Graph 관련
     implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")
     implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
+
     //Firebase Bom 관련
     implementation(platform("com.google.firebase:firebase-bom:32.0.0"))
-    //Firebase analytics 관련
-    implementation("com.google.firebase:firebase-analytics-ktx")
-    //Firebase auth 관련
-    implementation("com.google.firebase:firebase-auth-ktx:22.0.0")
-    //Google Play Services의 base 관련
-    implementation("com.google.android.gms:play-services-base:18.2.0")
-    //Google Play Services의 auth 관련
-    implementation("com.google.android.gms:play-services-auth:20.5.0")
+    implementation("com.google.firebase:firebase-analytics-ktx") //analytics 관련
+    implementation("com.google.firebase:firebase-auth-ktx:22.0.0") //auth 관련
+
+    //Google Play Services 관련
+    implementation("com.google.android.gms:play-services-base:18.2.0") //base 관련
+    implementation("com.google.android.gms:play-services-auth:20.5.0") //auth 관련
+
     //Fragment ktx(ViewModel 초기화) 관련
     implementation ("androidx.fragment:fragment-ktx:1.5.7")
+
     //Moshi(Json Converter) 관련
     implementation ("com.squareup.moshi:moshi:1.14.0")
 
+    //OkHttp(네트워크 통신) 관련
+    implementation ("com.squareup.okhttp3:okhttp:4.9.1")
+    implementation ("com.squareup.okhttp3:logging-interceptor:4.9.1") //interceptor 관련
+
+    //네트워크 통신을 위한 retrofit + moshi(Json Converter) 관련
+    implementation ("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation ("com.squareup.retrofit2:converter-moshi:2.9.0") //retrofit의 moshi 관련
 }

--- a/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
@@ -1,6 +1,7 @@
 package com.mbj.ssassamarket
 
 import android.app.Application
+import com.mbj.ssassamarket.util.AppContainer
 import com.mbj.ssassamarket.util.PreferenceManager
 
 class SsaSsaMarketApplication : Application() {
@@ -8,9 +9,11 @@ class SsaSsaMarketApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         preferenceManager = PreferenceManager(this)
+        appContainer = AppContainer()
     }
 
     companion object {
         lateinit var preferenceManager: PreferenceManager
+        lateinit var appContainer: AppContainer
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/model/User.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/model/User.kt
@@ -1,0 +1,12 @@
+package com.mbj.ssassamarket.data.model
+
+import com.squareup.moshi.Json
+
+data class User(
+    @Json(name = "userId")
+    val userId: String?,
+    @Json(name = "userName")
+    val userName: String?,
+    @Json(name = "latitudeAndLongitude")
+    val latitudeAndLongitude: String?,
+)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
@@ -1,0 +1,10 @@
+package com.mbj.ssassamarket.data.source
+
+import com.mbj.ssassamarket.data.source.remote.MarketNetworkDataSource
+
+class UserInfoRepository(private val marketNetworkDataSource: MarketNetworkDataSource) {
+
+    suspend fun currentUserExists(): Boolean {
+        return marketNetworkDataSource.currentUserExists()
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
@@ -11,4 +11,8 @@ class UserInfoRepository(private val marketNetworkDataSource: MarketNetworkDataS
     suspend fun addUser(nickname: String): Boolean {
         return marketNetworkDataSource.addUser(nickname)
     }
+
+    suspend fun checkDuplicateUserName(nickname: String): Boolean {
+        return marketNetworkDataSource.checkDuplicateUserName(nickname)
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
@@ -7,4 +7,8 @@ class UserInfoRepository(private val marketNetworkDataSource: MarketNetworkDataS
     suspend fun currentUserExists(): Boolean {
         return marketNetworkDataSource.currentUserExists()
     }
+
+    suspend fun addUser(nickname: String): Boolean {
+        return marketNetworkDataSource.addUser(nickname)
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -1,0 +1,36 @@
+package com.mbj.ssassamarket.data.source.remote
+
+import com.mbj.ssassamarket.BuildConfig
+import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+interface ApiClient {
+
+    companion object {
+        private const val FIREBASE_BASE_URL = BuildConfig.FIREBASE_BASE_URL
+
+        fun create(): ApiClient {
+            val logger = HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
+
+            val client = OkHttpClient.Builder()
+                .addInterceptor(logger)
+                .build()
+
+            val moshi: Moshi = Moshi.Builder()
+                .build()
+
+            return Retrofit.Builder()
+                .baseUrl(FIREBASE_BASE_URL)
+                .client(client)
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .build()
+                .create(ApiClient::class.java)
+        }
+    }
+}
+

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -21,7 +21,9 @@ interface ApiClient {
     ): Response<Map<String, String>>
 
     @GET("user.json")
-    suspend fun getUser(): Response<Map<String, Map<String, User>>>
+    suspend fun getUser(
+        @Query("auth") auth: String
+    ): Response<Map<String, Map<String, User>>>
 
     companion object {
         private const val FIREBASE_BASE_URL = BuildConfig.FIREBASE_BASE_URL

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -13,6 +13,13 @@ import retrofit2.http.*
 
 interface ApiClient {
 
+    @POST("user/{uId}.json")
+    suspend fun addUser(
+        @Path("uId") uId: String,
+        @Body user: User,
+        @Query("auth") auth: String
+    ): Response<Map<String, String>>
+
     @GET("user.json")
     suspend fun getUser(): Response<Map<String, Map<String, User>>>
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -1,13 +1,20 @@
 package com.mbj.ssassamarket.data.source.remote
 
 import com.mbj.ssassamarket.BuildConfig
+import com.mbj.ssassamarket.data.model.User
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.*
 
 interface ApiClient {
+
+    @GET("user.json")
+    suspend fun getUser(): Response<Map<String, Map<String, User>>>
 
     companion object {
         private const val FIREBASE_BASE_URL = BuildConfig.FIREBASE_BASE_URL
@@ -22,6 +29,7 @@ interface ApiClient {
                 .build()
 
             val moshi: Moshi = Moshi.Builder()
+                .add(KotlinJsonAdapterFactory())
                 .build()
 
             return Retrofit.Builder()

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -3,6 +3,8 @@ package com.mbj.ssassamarket.data.source.remote
 import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.mbj.ssassamarket.SsaSsaMarketApplication
+import com.mbj.ssassamarket.data.model.User
+import kotlinx.coroutines.tasks.await
 
 class FirebaseDataSource() : MarketNetworkDataSource {
 
@@ -23,6 +25,28 @@ class FirebaseDataSource() : MarketNetworkDataSource {
             }
         } catch (e: Exception) {
             Log.d("currentUserExists Error", e.toString())
+        }
+
+        return false
+    }
+
+    override suspend fun addUser(nickname: String): Boolean {
+        val user = FirebaseAuth.getInstance().currentUser
+        val idToken = user?.getIdToken(true)?.await()?.token
+        val userItem = User(user?.uid, nickname, null)
+
+        if (idToken != null) {
+            try {
+                val response = apiClient.addUser(user.uid, userItem, idToken)
+                if (response.isSuccessful) {
+                    Log.d("postUser Success", "${response.body()}")
+                    return true
+                } else {
+                    Log.e("FirebaseDataSource", "postUser Error: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                Log.e("FirebaseDataSource", "postUser Error: $e")
+            }
         }
 
         return false

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -1,0 +1,30 @@
+package com.mbj.ssassamarket.data.source.remote
+
+import android.util.Log
+import com.google.firebase.auth.FirebaseAuth
+import com.mbj.ssassamarket.SsaSsaMarketApplication
+
+class FirebaseDataSource() : MarketNetworkDataSource {
+
+    private val apiClient = SsaSsaMarketApplication.appContainer.provideApiClient()
+
+    override suspend fun currentUserExists(): Boolean {
+        val uId = FirebaseAuth.getInstance().currentUser?.uid
+
+        try {
+            val response = apiClient.getUser()
+            if (response.isSuccessful) {
+                val users = response.body()
+                if (users != null) {
+                    return users.containsKey(uId)
+                }
+            } else {
+                Log.d("currentUserExists Error", "${Exception(response.code().toString())}")
+            }
+        } catch (e: Exception) {
+            Log.d("currentUserExists Error", e.toString())
+        }
+
+        return false
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -20,7 +20,7 @@ class FirebaseDataSource() : MarketNetworkDataSource {
                 if (response.isSuccessful) {
                     val users = response.body()
                     if (users != null) {
-                        return users.containsKey(user?.uid)
+                        return users.containsKey(user.uid)
                     }
                 } else {
                     Log.d("currentUserExists Error", "${Exception(response.code().toString())}")

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -1,0 +1,5 @@
+package com.mbj.ssassamarket.data.source.remote
+
+interface MarketNetworkDataSource {
+    suspend fun currentUserExists(): Boolean
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -3,4 +3,5 @@ package com.mbj.ssassamarket.data.source.remote
 interface MarketNetworkDataSource {
     suspend fun currentUserExists(): Boolean
     suspend fun addUser(nickname: String): Boolean
+    suspend fun checkDuplicateUserName(nickname: String): Boolean
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -2,4 +2,5 @@ package com.mbj.ssassamarket.data.source.remote
 
 interface MarketNetworkDataSource {
     suspend fun currentUserExists(): Boolean
+    suspend fun addUser(nickname: String): Boolean
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/HomeFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/HomeFragment.kt
@@ -1,0 +1,11 @@
+package com.mbj.ssassamarket.ui
+
+
+import com.mbj.ssassamarket.R
+import com.mbj.ssassamarket.databinding.FragmentHomeBinding
+
+class HomeFragment : BaseFragment() {
+
+    override val binding get() = _binding as FragmentHomeBinding
+    override val layoutId: Int get() = R.layout.fragment_home
+}

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -11,7 +11,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
@@ -100,8 +99,7 @@ class LogInFragment : BaseFragment() {
 
     private fun handleGoogleOneTapSignInResult(resultCode: Int, data: Intent?) {
         if (resultCode == Activity.RESULT_OK) {
-            val intent = data
-            val credential = oneTapClient.getSignInCredentialFromIntent(intent)
+            val credential = oneTapClient.getSignInCredentialFromIntent(data)
             val googleIdToken = credential.googleIdToken
             if (googleIdToken != null) {
                 firebaseAuthWithGoogle(googleIdToken)

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInFragment.kt
@@ -200,14 +200,6 @@ class LogInFragment : BaseFragment() {
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     viewModel.currentUserExists()
-//                    lifecycleScope.launch {
-//                        if (viewModel.currentUserExists()) {
-//                            navigateToHomeFragment()
-//                            showToast(R.string.setting_nickname_success)
-//                        } else {
-//                            navigateToSettingNicknameFragment()
-//                        }
-//                    }
                 } else {
                     Log.e(TAG, "Firebase authentication failed", task.exception)
                     when (task.exception?.message) {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
@@ -1,19 +1,47 @@
 package com.mbj.ssassamarket.ui.login
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.mbj.ssassamarket.SsaSsaMarketApplication
 import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.util.Constants.AUTO_LOGIN
+import com.mbj.ssassamarket.util.Event
+import kotlinx.coroutines.launch
 
 class LogInViewModel(private val userInfoRepository: UserInfoRepository) : ViewModel() {
 
     var autoLoginEnabled = MutableLiveData<Boolean>(SsaSsaMarketApplication.preferenceManager.getBoolean(AUTO_LOGIN, false))
 
-    suspend fun currentUserExists(): Boolean {
-        return userInfoRepository.currentUserExists()
+    private val _preUploadCompleted = MutableLiveData<Boolean>()
+    val preUploadCompleted: LiveData<Boolean>
+        get() = _preUploadCompleted
+
+    private val _addUserResult = MutableLiveData<Boolean>()
+    val addUserResult: LiveData<Boolean>
+        get() = _addUserResult
+
+    private val _uploadSuccess = MutableLiveData<Event<Boolean>>()
+    val uploadSuccess: LiveData<Event<Boolean>>
+        get() = _uploadSuccess
+
+    fun currentUserExists() {
+        viewModelScope.launch {
+            _preUploadCompleted.value = false
+            _addUserResult.value = userInfoRepository.currentUserExists()
+        }
+    }
+
+    fun handleGetResponse(responseBoolean: Boolean) {
+        if (responseBoolean) {
+            _uploadSuccess.value = Event(true)
+        } else {
+            _uploadSuccess.value = Event(false)
+        }
+        _preUploadCompleted.value = true
     }
 
     companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/login/LogInViewModel.kt
@@ -2,9 +2,25 @@ package com.mbj.ssassamarket.ui.login
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.mbj.ssassamarket.SsaSsaMarketApplication
+import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.util.Constants.AUTO_LOGIN
 
-class LogInViewModel() : ViewModel() {
+class LogInViewModel(private val userInfoRepository: UserInfoRepository) : ViewModel() {
+
     var autoLoginEnabled = MutableLiveData<Boolean>(SsaSsaMarketApplication.preferenceManager.getBoolean(AUTO_LOGIN, false))
+
+    suspend fun currentUserExists(): Boolean {
+        return userInfoRepository.currentUserExists()
+    }
+
+    companion object {
+        fun provideFactory(repository: UserInfoRepository) = viewModelFactory {
+            initializer {
+                LogInViewModel(repository)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.mbj.marketapp.util.EventObserver
 import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.data.source.remote.FirebaseDataSource
@@ -17,6 +16,7 @@ import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
 import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
 import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
 import com.mbj.ssassamarket.util.Constants.SUCCESS
+import com.mbj.ssassamarket.util.EventObserver
 import com.mbj.ssassamarket.util.ProgressDialogFragment
 
 class SettingNicknameFragment : BaseFragment() {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -2,60 +2,86 @@ package com.mbj.ssassamarket.ui.settingnickname
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.core.content.ContextCompat
-import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.mbj.marketapp.util.EventObserver
 import com.mbj.ssassamarket.R
+import com.mbj.ssassamarket.data.source.UserInfoRepository
+import com.mbj.ssassamarket.data.source.remote.FirebaseDataSource
 import com.mbj.ssassamarket.databinding.FragmentSettingNicknameBinding
 import com.mbj.ssassamarket.ui.BaseFragment
-import com.mbj.ssassamarket.util.Constants.NICKNAME_PATTERN
+import com.mbj.ssassamarket.util.Constants.FAILURE
+import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
+import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
+import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
+import com.mbj.ssassamarket.util.Constants.SUCCESS
+import com.mbj.ssassamarket.util.ProgressDialogFragment
 
 class SettingNicknameFragment : BaseFragment() {
 
     override val binding get() = _binding as FragmentSettingNicknameBinding
     override val layoutId: Int get() = R.layout.fragment_setting_nickname
+    private var loadingProgressDialog: ProgressDialogFragment? = null
+    private val viewModel by viewModels<SettingNicknameViewModel> {
+        SettingNicknameViewModel.provideFactory(UserInfoRepository(FirebaseDataSource()))
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        setupViews()
-    }
-
-    private fun setupViews() {
+        binding.viewModel = viewModel
         binding.settingNicknameRegisterBt.setOnClickListener {
-            if (validateNickname()) {
+            viewModel.addUser()
+        }
+        viewModel.addUserResult.observe(viewLifecycleOwner) { addUserResult ->
+            viewModel.handlePostResponse(addUserResult)
+        }
+        viewModel.nickname.observe(viewLifecycleOwner) { nickname ->
+            viewModel.validateNickname()
+        }
+        viewModel.nicknameErrorMessage.observe(viewLifecycleOwner) { nicknameErrorMessage ->
+            when (nicknameErrorMessage) {
+                NICKNAME_REQUEST -> {
+                    setButtonBackground(R.color.orange_100)
+                    binding.settingNicknameTil.error =
+                        getString(R.string.setting_nickname_request_nickname)
+                }
+                NICKNAME_ERROR -> {
+                    setButtonBackground(R.color.orange_100)
+                    binding.settingNicknameTil.error =
+                        getString(R.string.setting_nickname_error_nickname)
+                }
+                NICKNAME_VALID -> {
+                    setButtonBackground(R.color.orange_700)
+                    binding.settingNicknameTil.error = null
+                }
+            }
+        }
+        viewModel.preUploadCompleted.observe(viewLifecycleOwner) { preUploadCompleted ->
+            if (preUploadCompleted == false) {
+                if (loadingProgressDialog == null) {
+                    loadingProgressDialog = ProgressDialogFragment()
+                    loadingProgressDialog?.show(childFragmentManager, "progress_dialog")
+                }
+            } else {
+                loadingProgressDialog?.dismissAllowingStateLoss()
+                loadingProgressDialog = null
+            }
+        }
+
+        viewModel.uploadSuccess.observe(viewLifecycleOwner, EventObserver { uploadSuccess ->
+            if (uploadSuccess) {
                 navigateToHomeFragment()
-            } else {
-                binding.settingNicknameTiet.requestFocus()
             }
-        }
+        })
 
-        binding.settingNicknameTiet.doAfterTextChanged {
-            if (validateNickname()) {
-                setButtonBackground(R.color.orange_700)
-            } else {
-                setButtonBackground(R.color.orange_100)
+        viewModel.responseToastMessage.observe(viewLifecycleOwner, EventObserver { message ->
+            when (message) {
+                SUCCESS -> showToast(R.string.setting_nickname_success)
+                FAILURE -> showToast(R.string.setting_nickname_error_nickname)
             }
-        }
-    }
-
-    private fun validateNickname(): Boolean {
-        val value: String = binding.settingNicknameTiet.text.toString()
-
-        return when {
-            value.isEmpty() -> {
-                binding.settingNicknameTil.error = getString(R.string.setting_nickname_request_nickname)
-                false
-            }
-            !value.matches(NICKNAME_PATTERN.toRegex()) -> {
-                binding.settingNicknameTil.error = getString(R.string.setting_nickname_error_nickname)
-                false
-            }
-            else -> {
-                binding.settingNicknameTil.error = null
-                true
-            }
-        }
+        })
     }
 
     private fun setButtonBackground(colorResId: Int) {
@@ -66,5 +92,9 @@ class SettingNicknameFragment : BaseFragment() {
     private fun navigateToHomeFragment() {
         val action = SettingNicknameFragmentDirections.actionSettingNicknameFragmentToHomeFragment()
         findNavController().navigate(action)
+    }
+
+    private fun showToast(messageResId: Int) {
+        Toast.makeText(requireContext(), messageResId, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -31,9 +31,6 @@ class SettingNicknameFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-        binding.settingNicknameRegisterBt.setOnClickListener {
-            viewModel.addUser()
-        }
         viewModel.addUserResult.observe(viewLifecycleOwner) { addUserResult ->
             viewModel.handlePostResponse(addUserResult)
         }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -11,7 +11,7 @@ import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.data.source.remote.FirebaseDataSource
 import com.mbj.ssassamarket.databinding.FragmentSettingNicknameBinding
 import com.mbj.ssassamarket.ui.BaseFragment
-import com.mbj.ssassamarket.util.Constants.FAILURE
+import com.mbj.ssassamarket.util.Constants.NICKNAME_DUPLICATE
 import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
 import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
 import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
@@ -79,7 +79,8 @@ class SettingNicknameFragment : BaseFragment() {
         viewModel.responseToastMessage.observe(viewLifecycleOwner, EventObserver { message ->
             when (message) {
                 SUCCESS -> showToast(R.string.setting_nickname_success)
-                FAILURE -> showToast(R.string.setting_nickname_error_nickname)
+                NICKNAME_DUPLICATE -> showToast(R.string.setting_nickname_duplicate)
+                NICKNAME_ERROR -> showToast(R.string.setting_nickname_error_nickname)
             }
         })
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -1,11 +1,70 @@
 package com.mbj.ssassamarket.ui.settingnickname
 
+import android.os.Bundle
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
+import androidx.navigation.fragment.findNavController
 import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.databinding.FragmentSettingNicknameBinding
 import com.mbj.ssassamarket.ui.BaseFragment
+import com.mbj.ssassamarket.util.Constants.NICKNAME_PATTERN
 
 class SettingNicknameFragment : BaseFragment() {
 
     override val binding get() = _binding as FragmentSettingNicknameBinding
     override val layoutId: Int get() = R.layout.fragment_setting_nickname
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupViews()
+    }
+
+    private fun setupViews() {
+        binding.settingNicknameRegisterBt.setOnClickListener {
+            if (validateNickname()) {
+                navigateToHomeFragment()
+            } else {
+                binding.settingNicknameTiet.requestFocus()
+            }
+        }
+
+        binding.settingNicknameTiet.doAfterTextChanged {
+            if (validateNickname()) {
+                setButtonBackground(R.color.orange_700)
+            } else {
+                setButtonBackground(R.color.orange_100)
+            }
+        }
+    }
+
+    private fun validateNickname(): Boolean {
+        val value: String = binding.settingNicknameTiet.text.toString()
+
+        return when {
+            value.isEmpty() -> {
+                binding.settingNicknameTil.error = getString(R.string.setting_nickname_request_nickname)
+                false
+            }
+            !value.matches(NICKNAME_PATTERN.toRegex()) -> {
+                binding.settingNicknameTil.error = getString(R.string.setting_nickname_error_nickname)
+                false
+            }
+            else -> {
+                binding.settingNicknameTil.error = null
+                true
+            }
+        }
+    }
+
+    private fun setButtonBackground(colorResId: Int) {
+        val color = ContextCompat.getColor(requireContext(), colorResId)
+        binding.settingNicknameRegisterBt.setBackgroundColor(color)
+    }
+
+    private fun navigateToHomeFragment() {
+        val action = SettingNicknameFragmentDirections.actionSettingNicknameFragmentToHomeFragment()
+        findNavController().navigate(action)
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameFragment.kt
@@ -77,6 +77,7 @@ class SettingNicknameFragment : BaseFragment() {
             when (message) {
                 SUCCESS -> showToast(R.string.setting_nickname_success)
                 NICKNAME_DUPLICATE -> showToast(R.string.setting_nickname_duplicate)
+                NICKNAME_REQUEST -> showToast(R.string.setting_nickname_request_nickname)
                 NICKNAME_ERROR -> showToast(R.string.setting_nickname_error_nickname)
             }
         })

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.util.Constants
-import com.mbj.ssassamarket.util.Constants.FAILURE
+import com.mbj.ssassamarket.util.Constants.NICKNAME_DUPLICATE
 import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
 import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
 import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
@@ -43,11 +43,18 @@ class SettingNicknameViewModel(private val repository: UserInfoRepository) : Vie
     fun addUser() {
         viewModelScope.launch {
             _preUploadCompleted.value = false
-            if (validateNickname()) {
+            if (validateNickname() && !repository.checkDuplicateUserName(nickname.value.toString())) {
                 _addUserResult.value = repository.addUser(nickname.value.toString())
-            } else {
+            }
+            else if(repository.checkDuplicateUserName(nickname.value.toString())) {
                 _addUserResult.value = false
                 _preUploadCompleted.value = true
+                _responseToastMessage.value = Event(NICKNAME_DUPLICATE)
+            }
+            else {
+                _addUserResult.value = false
+                _preUploadCompleted.value = true
+                _responseToastMessage.value = Event(NICKNAME_ERROR)
             }
         }
     }
@@ -77,7 +84,6 @@ class SettingNicknameViewModel(private val repository: UserInfoRepository) : Vie
             _responseToastMessage.value = Event(SUCCESS)
         } else {
             _uploadSuccess.value = Event(false)
-            _responseToastMessage.value = Event(FAILURE)
         }
         _preUploadCompleted.value = true
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
@@ -43,18 +43,21 @@ class SettingNicknameViewModel(private val repository: UserInfoRepository) : Vie
     fun addUser() {
         viewModelScope.launch {
             _preUploadCompleted.value = false
-            if (validateNickname() && !repository.checkDuplicateUserName(nickname.value.toString())) {
-                _addUserResult.value = repository.addUser(nickname.value.toString())
-            }
-            else if(repository.checkDuplicateUserName(nickname.value.toString())) {
+
+            if (nickname.value.isNullOrEmpty()) {
                 _addUserResult.value = false
                 _preUploadCompleted.value = true
-                _responseToastMessage.value = Event(NICKNAME_DUPLICATE)
-            }
-            else {
+                _responseToastMessage.value = Event(NICKNAME_REQUEST)
+            } else if (!validateNickname()) {
                 _addUserResult.value = false
                 _preUploadCompleted.value = true
                 _responseToastMessage.value = Event(NICKNAME_ERROR)
+            } else if (repository.checkDuplicateUserName(nickname.value.toString())) {
+                _addUserResult.value = false
+                _preUploadCompleted.value = true
+                _responseToastMessage.value = Event(NICKNAME_DUPLICATE)
+            } else {
+                _addUserResult.value = repository.addUser(nickname.value.toString())
             }
         }
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.mbj.marketapp.util.Event
 import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.util.Constants
 import com.mbj.ssassamarket.util.Constants.FAILURE
@@ -14,6 +13,7 @@ import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
 import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
 import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
 import com.mbj.ssassamarket.util.Constants.SUCCESS
+import com.mbj.ssassamarket.util.Event
 import kotlinx.coroutines.launch
 
 class SettingNicknameViewModel(private val repository: UserInfoRepository) : ViewModel() {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/settingnickname/SettingNicknameViewModel.kt
@@ -1,0 +1,92 @@
+package com.mbj.ssassamarket.ui.settingnickname
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.mbj.marketapp.util.Event
+import com.mbj.ssassamarket.data.source.UserInfoRepository
+import com.mbj.ssassamarket.util.Constants
+import com.mbj.ssassamarket.util.Constants.FAILURE
+import com.mbj.ssassamarket.util.Constants.NICKNAME_ERROR
+import com.mbj.ssassamarket.util.Constants.NICKNAME_REQUEST
+import com.mbj.ssassamarket.util.Constants.NICKNAME_VALID
+import com.mbj.ssassamarket.util.Constants.SUCCESS
+import kotlinx.coroutines.launch
+
+class SettingNicknameViewModel(private val repository: UserInfoRepository) : ViewModel() {
+
+    val nickname = MutableLiveData<String>()
+
+    private val _nicknameErrorMessage = MutableLiveData<String>()
+    val nicknameErrorMessage: LiveData<String>
+        get() = _nicknameErrorMessage
+
+    private val _addUserResult = MutableLiveData<Boolean>()
+    val addUserResult: LiveData<Boolean>
+        get() = _addUserResult
+
+    private val _preUploadCompleted = MutableLiveData<Boolean>()
+    val preUploadCompleted: LiveData<Boolean>
+        get() = _preUploadCompleted
+
+    private val _uploadSuccess = MutableLiveData<Event<Boolean>>()
+    val uploadSuccess: LiveData<Event<Boolean>>
+        get() = _uploadSuccess
+
+    private val _responseToastMessage = MutableLiveData<Event<String>>()
+    val responseToastMessage: LiveData<Event<String>>
+        get() = _responseToastMessage
+
+    fun addUser() {
+        viewModelScope.launch {
+            _preUploadCompleted.value = false
+            if (validateNickname()) {
+                _addUserResult.value = repository.addUser(nickname.value.toString())
+            } else {
+                _addUserResult.value = false
+                _preUploadCompleted.value = true
+            }
+        }
+    }
+
+    fun validateNickname(): Boolean {
+        val value: String = nickname.value ?: ""
+
+        return when {
+            value.isEmpty() -> {
+                _nicknameErrorMessage.value = NICKNAME_REQUEST
+                false
+            }
+            !value.matches(Constants.NICKNAME_PATTERN.toRegex()) -> {
+                _nicknameErrorMessage.value = NICKNAME_ERROR
+                false
+            }
+            else -> {
+                _nicknameErrorMessage.value = NICKNAME_VALID
+                true
+            }
+        }
+    }
+
+    fun handlePostResponse(responseBoolean: Boolean) {
+        if (responseBoolean) {
+            _uploadSuccess.value = Event(true)
+            _responseToastMessage.value = Event(SUCCESS)
+        } else {
+            _uploadSuccess.value = Event(false)
+            _responseToastMessage.value = Event(FAILURE)
+        }
+        _preUploadCompleted.value = true
+    }
+
+    companion object {
+        fun provideFactory(repository: UserInfoRepository) = viewModelFactory {
+            initializer {
+                SettingNicknameViewModel(repository)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/AppContainer.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/AppContainer.kt
@@ -1,0 +1,14 @@
+package com.mbj.ssassamarket.util
+
+import com.mbj.ssassamarket.data.source.remote.ApiClient
+
+class AppContainer {
+
+    private var apiClient: ApiClient? = null
+
+    fun provideApiClient(): ApiClient {
+        return apiClient ?: ApiClient.create().apply {
+            apiClient = this
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
@@ -6,7 +6,7 @@ object Constants {
     const val NICKNAME_REQUEST = "setting_nickname_request_nickname"
     const val NICKNAME_ERROR = "setting_nickname_error_nickname"
     const val NICKNAME_VALID = "setting_nickname_valid"
+    const val NICKNAME_DUPLICATE = "setting_nickname_duplicate"
     const val SUCCESS = "success"
-    const val FAILURE = "failed"
     const val PROGRESS_DIALOG = "progressDialog"
 }

--- a/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
@@ -2,4 +2,5 @@ package com.mbj.ssassamarket.util
 
 object Constants {
     const val AUTO_LOGIN = "autoLogin"
+    const val NICKNAME_PATTERN = "^[a-zA-Z0-9가-힣]{2,8}$"
 }

--- a/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Constants.kt
@@ -3,4 +3,10 @@ package com.mbj.ssassamarket.util
 object Constants {
     const val AUTO_LOGIN = "autoLogin"
     const val NICKNAME_PATTERN = "^[a-zA-Z0-9가-힣]{2,8}$"
+    const val NICKNAME_REQUEST = "setting_nickname_request_nickname"
+    const val NICKNAME_ERROR = "setting_nickname_error_nickname"
+    const val NICKNAME_VALID = "setting_nickname_valid"
+    const val SUCCESS = "success"
+    const val FAILURE = "failed"
+    const val PROGRESS_DIALOG = "progressDialog"
 }

--- a/app/src/main/java/com/mbj/ssassamarket/util/Event.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Event.kt
@@ -1,0 +1,15 @@
+package com.mbj.marketapp.util
+
+class Event<T>(private val content: T) {
+
+    private var hasBennHandled = false
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBennHandled) {
+            null
+        } else {
+            hasBennHandled = true
+            content
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/Event.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/Event.kt
@@ -1,4 +1,4 @@
-package com.mbj.marketapp.util
+package com.mbj.ssassamarket.util
 
 class Event<T>(private val content: T) {
 

--- a/app/src/main/java/com/mbj/ssassamarket/util/EventObserver.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/EventObserver.kt
@@ -1,0 +1,11 @@
+package com.mbj.marketapp.util
+
+import androidx.lifecycle.Observer
+
+class EventObserver<T>(private val onEventUnHandleContent: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(event: Event<T>) {
+        event?.getContentIfNotHandled()?.let {
+            onEventUnHandleContent(it)
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/EventObserver.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/EventObserver.kt
@@ -1,4 +1,4 @@
-package com.mbj.marketapp.util
+package com.mbj.ssassamarket.util
 
 import androidx.lifecycle.Observer
 

--- a/app/src/main/java/com/mbj/ssassamarket/util/ProgressDialogFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/ProgressDialogFragment.kt
@@ -1,0 +1,80 @@
+package com.mbj.ssassamarket.util
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Point
+import android.os.Build
+import android.os.Bundle
+import android.view.*
+import androidx.fragment.app.DialogFragment
+import com.mbj.ssassamarket.databinding.DialogWorkingProgressBinding
+
+class ProgressDialogFragment : DialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+
+        val binding = DialogWorkingProgressBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return super.onCreateDialog(savedInstanceState).apply {
+            setCancelable(false)
+            setCanceledOnTouchOutside(false)
+            setOnKeyListener { dialog, keyCode, event ->
+                return@setOnKeyListener keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        context?.setDialogSize(this, 0.9f, 0.2f)
+    }
+
+    private fun Context.setDialogSize(
+        dialogFragment: DialogFragment,
+        widthRatio: Float,
+        heightRatio: Float
+    ) {
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val window = dialogFragment.dialog?.window
+        val display = windowManager.defaultDisplay
+        val size = Point()
+
+        //가로모드인 지 확인함
+        val rotation = display.rotation
+        val isRotated = rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270
+
+        val x: Int
+        val y: Int
+
+        fun calculateSize(value: Int, ratio: Float): Int {
+            return (value * ratio).toInt()
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            display.getSize(size)
+        } else {
+            val windowMetrics = windowManager.currentWindowMetrics
+            val bounds = windowMetrics.bounds
+            size.x = bounds.width()
+            size.y = bounds.height()
+        }
+
+        //가로모드일 때 width, height 바꿈
+        if (isRotated) {
+            x = calculateSize(size.y, widthRatio)
+            y = calculateSize(size.x, heightRatio)
+        } else {
+            x = calculateSize(size.x, widthRatio)
+            y = calculateSize(size.y, heightRatio)
+        }
+
+        window?.setLayout(x, y)
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/util/ProgressIndicatorView.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/util/ProgressIndicatorView.kt
@@ -1,0 +1,19 @@
+package com.mbj.ssassamarket.util
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.mbj.ssassamarket.databinding.ProgressIndicatorBinding
+
+class ProgressIndicatorView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet?,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr, defStyleRes){
+
+    init {
+        ProgressIndicatorBinding.inflate(LayoutInflater.from(context), this)
+    }
+}

--- a/app/src/main/res/layout/dialog_working_progress.xml
+++ b/app/src/main/res/layout/dialog_working_progress.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/dialog_working_loading_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/dialog_loading_text"
+        android:textColor="@color/orange_700"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toTopOf="@id/dialog_working_piv"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="parent" />
+
+    <com.mbj.ssassamarket.util.ProgressIndicatorView
+        android:id="@+id/dialog_working_piv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dialog_working_loading_tv" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.HomeFragment">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_setting_nickname.xml
+++ b/app/src/main/res/layout/fragment_setting_nickname.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <variable
+            name="viewModel"
+            type="com.mbj.ssassamarket.ui.settingnickname.SettingNicknameViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -42,7 +44,8 @@
                 android:hint="@string/setting_nickname_hint"
                 android:imeOptions="actionNext"
                 android:inputType="text"
-                android:maxLength="8" />
+                android:maxLength="8"
+                android:text="@={viewModel.nickname}"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button

--- a/app/src/main/res/layout/fragment_setting_nickname.xml
+++ b/app/src/main/res/layout/fragment_setting_nickname.xml
@@ -46,6 +46,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
+            android:id="@+id/setting_nickname_register_bt"
             style="@style/ButtonStyle"
             android:layout_width="70dp"
             android:layout_height="50dp"

--- a/app/src/main/res/layout/fragment_setting_nickname.xml
+++ b/app/src/main/res/layout/fragment_setting_nickname.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.mbj.ssassamarket.ui.settingnickname.SettingNicknameViewModel" />
@@ -45,7 +46,7 @@
                 android:imeOptions="actionNext"
                 android:inputType="text"
                 android:maxLength="8"
-                android:text="@={viewModel.nickname}"/>
+                android:text="@={viewModel.nickname}" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -53,6 +54,7 @@
             style="@style/ButtonStyle"
             android:layout_width="70dp"
             android:layout_height="50dp"
+            android:onClick="@{() -> viewModel.addUser()}"
             android:text="@string/setting_nickname_register"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/progress_indicator.xml
+++ b/app/src/main/res/layout/progress_indicator.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/working_progress_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:indicatorColor="@color/orange_700"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</merge>

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -15,6 +15,11 @@
             app:destination="@id/settingNicknameFragment"
             app:popUpTo="@id/logInFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_logInFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/logInFragment"
+            app:popUpToInclusive="true"/>
     </fragment>
     <fragment
         android:id="@+id/settingNicknameFragment"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -9,7 +9,7 @@
         android:id="@+id/logInFragment"
         android:name="com.mbj.ssassamarket.ui.login.LogInFragment"
         android:label="fragment_log_in"
-        tools:layout="@layout/fragment_log_in" >
+        tools:layout="@layout/fragment_log_in">
         <action
             android:id="@+id/action_logInFragment_to_settingNicknameFragment"
             app:destination="@id/settingNicknameFragment"
@@ -19,5 +19,15 @@
     <fragment
         android:id="@+id/settingNicknameFragment"
         android:name="com.mbj.ssassamarket.ui.settingnickname.SettingNicknameFragment"
-        android:label="SettingNicknameFragment" />
+        android:label="SettingNicknameFragment">
+        <action
+            android:id="@+id/action_settingNicknameFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/settingNicknameFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.mbj.ssassamarket.ui.HomeFragment"
+        android:label="HomeFragment" />
 </navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="orange_100">#1BFC5230</color>
+    <color name="orange_700">#F44336</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="log_in_error_firebase">문의글을 남겨주세요</string>
     <string name="setting_nickname_register">등록</string>
     <string name="setting_nickname_hint">닉네임을 입력해주세요.</string>
+    <string name="setting_nickname_request_nickname">닉네임을 입력해주세요.</string>
+    <string name="setting_nickname_error_nickname">닉네임 형식이 잘못 되었습니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="setting_nickname_error_nickname">닉네임 형식이 잘못 되었습니다.</string>
     <string name="setting_nickname_success">SsaSsa Market에 오신것을 환영합니다.</string>
     <string name="dialog_loading_text">잠시 기다려주세요</string>
+    <string name="setting_nickname_duplicate">중복된 닉네임입니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="setting_nickname_request_nickname">닉네임을 입력해주세요.</string>
     <string name="setting_nickname_error_nickname">닉네임 형식이 잘못 되었습니다.</string>
     <string name="setting_nickname_success">SsaSsa Market에 오신것을 환영합니다.</string>
+    <string name="dialog_loading_text">잠시 기다려주세요</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="setting_nickname_hint">닉네임을 입력해주세요.</string>
     <string name="setting_nickname_request_nickname">닉네임을 입력해주세요.</string>
     <string name="setting_nickname_error_nickname">닉네임 형식이 잘못 되었습니다.</string>
+    <string name="setting_nickname_success">SsaSsa Market에 오신것을 환영합니다.</string>
 </resources>


### PR DESCRIPTION
## 1. Firebase Realtime Database 연동
1-1. Retrofit + Moshi Converter 사용 

 1-2. Firebase Realtime Database의 User 객체에 있는 정보를 가져오는 네트워크 통신 함수 구현( getUser() )
1-2-1. LogInFragment에서 getUser()를 사용하여 User 객체에 대한 정보들을 가져와 현재 나의 Firebase Auth Id의 값이 이미 존재한다면(이미 나의 계정이 존재한다면) HomeFragment로 이동하고 존재하지 않는다면 SettingFragement로 이동에 사용 ( currentUserExists() )
1-2-2. 상품을 등록할 때 addUser()를 사용하여 User 객체에 대한 정보들을 가져와 이 안의 nickname 필드를 모두 검사하여 유효성 검사하는데 사용 ( checkDuplicateUserName )

1-3. Firebase Realtime Database의 User 객체에 있는 정보를 가져오는 네트워크 통신 함수 구현( addUser() )
1-3-1. 입력된 닉네임 TextInputEditText의 유효성을 검사하여 통과를 한다면 addUser()를 통해 Firebase Realtime Database의 User 객체에 저장하는데 사용( addUser() )

## 2. 닉네임 유효성 검사
2-1. 입력된 닉네임 TextInputEditText를 Two-Way-Binding을 사용하여 양방향 데이터 연결을 활욯
2-2. 입력된 닉네임 TextInputEditText이 비어있는지, 닉네임 형식에 맞는지, 중복인지에 대해 유효성 검사 적용

## 3. 네트워크 통신 함수 대기시간 대응(LoadingProgressDialog 사용)
3-1. SettingNicknameFragment에서 네트워크 통신 함수인 addUser() 함수를 실행할 때 LoadingProgressDialog를 띄우도록 하고 결과값을 결과값 반환에 따라 LoadingProgressDialog를 닫도록 구현
3-2. LogInFragment에서 구글 로그인 성공 후 Firebase Realtime Database의 User객체에 나의 Firebase Auth Id의 값이 이미 존재하는지를 확인하는 네트워크 통신이 사용되기 때문에 LoadingProgressDialog를 띄우도록 하고 결과값을 반환한다면 결과값 반환에 따라 LoadingProgressDialog를 닫도록 구현

## 4. configuration 대응을 위한 ViewModel 사용
4-1. SettingNicknameFragment에서 네트워크 통신 함수인 addUser() 함수를 LiveData로 설정하고, 관찰하여 LoadingProgressDialog에 대해 가로모드로 바뀌었을때도 정상적으로 작동하도록함
4-2. LogInFragment에서 구글 로그인 성공 후 사용되는 네트워크 통신 함수인 currentUserExists() 함수를 LiveData로 설정하고, 관찰하여 LoadingProgressDialog에 대해 가로모드로 바뀌었을때도 정상적으로 작동하도록함
 
## 추후 구현해야 하는 내용
1. 스플래시 화면에서 자동로그인의 여부에 따른 첫번째 화면 결정
