### PR TITLE
[Feat/seller detail update] 판매자 상품 정보 업데이트 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,4 +117,7 @@ dependencies {
     //Hilt 관련
     implementation ("com.google.dagger:hilt-android:2.44")
     kapt ("com.google.dagger:hilt-compiler:2.44")
+
+    //SwipeRefreshLayout 관련
+    implementation ("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/model/ProductPostItem.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/model/ProductPostItem.kt
@@ -32,3 +32,9 @@ data class ProductPostItem(
     @Json(name = "favoriteList")
     val favoriteList: List<String?>? = null
 ) : java.io.Serializable
+
+data class PatchProductRequest(
+    val title: String,
+    val price: Int,
+    val content: String
+)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -1,8 +1,6 @@
 package com.mbj.ssassamarket.data.source
 
 import android.util.Log
-import com.mbj.ssassamarket.data.model.Category
-import com.mbj.ssassamarket.data.model.FilterType
 import com.mbj.ssassamarket.data.model.ImageContent
 import com.mbj.ssassamarket.data.model.ProductPostItem
 import com.mbj.ssassamarket.data.source.remote.MarketNetworkDataSource
@@ -43,42 +41,11 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
         }
     }
 
-    suspend fun getProduct(): List<ProductPostItem> {
+    suspend fun getProduct(): List<Pair<String, ProductPostItem>> {
         return try {
             marketNetworkDataSource.getProduct()
         } catch (e: Exception) {
             Log.e(TAG, "Product 가져 오던 중 에외가 발생하였습니다.", e)
-            emptyList()
-        }
-    }
-
-    suspend fun getProductByCategory(category: Category): List<ProductPostItem> {
-        return try {
-            val allProducts = getProduct()
-            allProducts.filter { it.category == category.label }
-        } catch (e: Exception) {
-            Log.e(TAG, "Exception while getting product by category", e)
-            emptyList()
-        }
-    }
-
-    suspend fun filterProductsByCategory(category: Category, filterType: FilterType): List<ProductPostItem> {
-        return try {
-            val allProducts = getProduct()
-            val filteredProducts = allProducts.filter { it.category == category.label }
-            when (filterType) {
-                FilterType.LATEST -> {
-                    filteredProducts.sortedByDescending { it.createdDate }
-                }
-                FilterType.PRICE -> {
-                    filteredProducts.sortedWith(compareBy { it.price })
-                }
-                FilterType.FAVORITE -> {
-                    filteredProducts.sortedWith(compareBy { it.favoriteCount })
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Exception while filtering products by category", e)
             emptyList()
         }
     }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -2,6 +2,7 @@ package com.mbj.ssassamarket.data.source
 
 import android.util.Log
 import com.mbj.ssassamarket.data.model.ImageContent
+import com.mbj.ssassamarket.data.model.PatchProductRequest
 import com.mbj.ssassamarket.data.model.ProductPostItem
 import com.mbj.ssassamarket.data.source.remote.MarketNetworkDataSource
 import javax.inject.Inject
@@ -47,6 +48,16 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
         } catch (e: Exception) {
             Log.e(TAG, "Product 가져 오던 중 에외가 발생하였습니다.", e)
             emptyList()
+        }
+    }
+
+    suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean {
+        return try {
+            marketNetworkDataSource.updateProduct(postId, request)
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "상품 업데이트 오류", e)
+            false
         }
     }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -1,5 +1,6 @@
 package com.mbj.ssassamarket.data.source.remote
 
+import com.mbj.ssassamarket.data.model.PatchProductRequest
 import com.mbj.ssassamarket.data.model.ProductPostItem
 import com.mbj.ssassamarket.data.model.User
 import retrofit2.Response
@@ -36,5 +37,12 @@ interface ApiClient {
     suspend fun getProduct(
         @Query("auth") auth: String
     ): Response<Map<String, ProductPostItem>>
+
+    @PATCH("posts/{postId}.json")
+    suspend fun updateProduct(
+        @Path("postId") postId: String,
+        @Body request: PatchProductRequest,
+        @Query("auth") auth: String
+    ): Response<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.storage.FirebaseStorage
 import com.mbj.ssassamarket.data.model.ImageContent
+import com.mbj.ssassamarket.data.model.PatchProductRequest
 import com.mbj.ssassamarket.data.model.ProductPostItem
 import com.mbj.ssassamarket.data.model.User
 import com.mbj.ssassamarket.util.DateFormat.getCurrentTime
@@ -13,7 +14,10 @@ import kotlinx.coroutines.tasks.await
 import retrofit2.Response
 import javax.inject.Inject
 
-class FirebaseDataSource @Inject constructor(private val apiClient: ApiClient, private val storage: FirebaseStorage) : MarketNetworkDataSource {
+class FirebaseDataSource @Inject constructor(
+    private val apiClient: ApiClient,
+    private val storage: FirebaseStorage
+) : MarketNetworkDataSource {
 
     override suspend fun currentUserExists(): Boolean {
         val (user, idToken) = getUserAndIdToken()
@@ -270,10 +274,26 @@ class FirebaseDataSource @Inject constructor(private val apiClient: ApiClient, p
                     Log.e(TAG, "getUserNameByUserId Error, Status Code: $statusCode")
                 }
             } catch (e: Exception) {
-                Log.e(TAG ,"getUserNameByUserId Error", e)
+                Log.e(TAG, "getUserNameByUserId Error", e)
             }
         }
         return null
+    }
+
+    override suspend fun updateProduct(postId: String, request: PatchProductRequest) {
+        val (user, idToken) = getUserAndIdToken()
+        if (idToken != null) {
+            try {
+                val response = apiClient.updateProduct(postId, request, idToken)
+                if (response.isSuccessful) {
+                    Log.d(TAG, "상품 업데이트 성공")
+                } else {
+                    Log.e(TAG, "상품 업데이트 실패 (Status Code: ${response.code()})")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "상품 업데이트 오류", e)
+            }
+        }
     }
 
     suspend fun getDownloadUrl(imageLocation: String): String {

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -2,6 +2,7 @@ package com.mbj.ssassamarket.data.source.remote
 
 import com.google.firebase.auth.FirebaseUser
 import com.mbj.ssassamarket.data.model.ImageContent
+import com.mbj.ssassamarket.data.model.PatchProductRequest
 import com.mbj.ssassamarket.data.model.ProductPostItem
 
 interface MarketNetworkDataSource {
@@ -26,4 +27,5 @@ interface MarketNetworkDataSource {
     suspend fun getProduct(): List<Pair<String, ProductPostItem>>
     suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
     suspend fun getUserNameByUserId(userIdToken: String) : String?
+    suspend fun updateProduct(postId: String, request: PatchProductRequest)
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -23,7 +23,7 @@ interface MarketNetworkDataSource {
     ): Boolean
     suspend fun getMyDataId(): String?
     suspend fun updateMyLatLng(latLng: String): Boolean
-    suspend fun getProduct(): List<ProductPostItem>
+    suspend fun getProduct(): List<Pair<String, ProductPostItem>>
     suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
     suspend fun getUserNameByUserId(userIdToken: String) : String?
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/common/ProductClickListener.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/common/ProductClickListener.kt
@@ -4,5 +4,5 @@ import com.mbj.ssassamarket.data.model.ProductPostItem
 
 interface ProductClickListener {
 
-    fun onProductClick(productPostItem: ProductPostItem)
+    fun onProductClick(productPostItem: Pair<String,ProductPostItem>)
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
@@ -3,7 +3,6 @@ package com.mbj.ssassamarket.ui.detail.seller
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
@@ -32,7 +31,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SellerFragment : BaseFragment() {
 
-    override val binding by lazy { FragmentSellerBinding.inflate(layoutInflater) }
+    override val binding get() = _binding as FragmentSellerBinding
     override val layoutId: Int = R.layout.fragment_seller
 
     private val args: SellerFragmentArgs by navArgs()
@@ -51,7 +50,7 @@ class SellerFragment : BaseFragment() {
     }
 
     private fun initViewModel() {
-        viewModel.initializeProduct(args.product)
+        viewModel.initializeProduct( args.postId, args.product)
     }
 
     private fun observeData() {
@@ -63,7 +62,7 @@ class SellerFragment : BaseFragment() {
 
         viewModel.nickname.observe(viewLifecycleOwner, EventObserver { nickname ->
             binding.detailReceiver.setDetailNicknameText(nickname)
-            viewModel.handlePostResponse(nickname)
+            viewModel.handleNicknameResponse(nickname)
         })
 
         viewModel.productNicknameCompleted.observe(viewLifecycleOwner, EventObserver { productNicknameCompleted ->
@@ -85,6 +84,27 @@ class SellerFragment : BaseFragment() {
             setDetailTitleTextColor(viewModel.isTitleMatch())
             setDetailPriceTextColor(viewModel.isPriceMatch())
             setDetailContentTextColor(viewModel.isContentMatch())
+        })
+
+        viewModel.productUpdatedResponse.observe(viewLifecycleOwner, EventObserver { response ->
+            viewModel.handleUpdateResponse(response)
+        })
+
+        viewModel.productUpdatedSuccess.observe(viewLifecycleOwner, EventObserver { success ->
+            if (success) {
+                findNavController().navigateUp()
+                showToast(R.string.product_update_success)
+            } else {
+                showToast(R.string.product_update_failed)
+            }
+        })
+
+        viewModel.productUpdateCompleted.observe(viewLifecycleOwner, EventObserver{ compleated ->
+            if(compleated) {
+                dismissLoadingDialog()
+            } else {
+                showLoadingDialog()
+            }
         })
     }
 
@@ -153,6 +173,7 @@ class SellerFragment : BaseFragment() {
             showConfirmationDialog()
         }
         binding.detailSubmitTv.setOnClickListener {
+            viewModel.updateProduct()
         }
         binding.detailBackIv.setOnClickListener {
             if (viewModel.isReadOnlyMode()) {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeAdapter.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeAdapter.kt
@@ -9,7 +9,7 @@ import com.mbj.ssassamarket.data.model.ProductPostItem
 import com.mbj.ssassamarket.databinding.RecyclerviewItemHomeProductBinding
 import com.mbj.ssassamarket.ui.common.ProductClickListener
 
-class HomeAdapter(private val productClickListener: ProductClickListener) : ListAdapter<ProductPostItem, HomeAdapter.HomeViewHolder>(homeDiffCallback) {
+class HomeAdapter(private val productClickListener: ProductClickListener) : ListAdapter<Pair<String,ProductPostItem>, HomeAdapter.HomeViewHolder>(homeDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeViewHolder {
         return HomeViewHolder.from(parent)
@@ -21,8 +21,8 @@ class HomeAdapter(private val productClickListener: ProductClickListener) : List
 
     class HomeViewHolder(val binding: RecyclerviewItemHomeProductBinding) : ViewHolder(binding.root) {
 
-        fun bind(productPostItem: ProductPostItem, productClickListener: ProductClickListener) {
-            binding.productPostItem = productPostItem
+        fun bind(productPostItem: Pair<String, ProductPostItem>, productClickListener: ProductClickListener) {
+            binding.productPostItem = productPostItem.second
             binding.root.setOnClickListener {
                 productClickListener.onProductClick(productPostItem)
             }
@@ -43,17 +43,17 @@ class HomeAdapter(private val productClickListener: ProductClickListener) : List
     }
 
     companion object {
-        private val homeDiffCallback = object : DiffUtil.ItemCallback<ProductPostItem>() {
+        private val homeDiffCallback = object : DiffUtil.ItemCallback<Pair<String,ProductPostItem>>() {
             override fun areItemsTheSame(
-                oldItem: ProductPostItem,
-                newItem: ProductPostItem
+                oldItem: Pair<String,ProductPostItem>,
+                newItem: Pair<String,ProductPostItem>
             ): Boolean {
-                return oldItem == newItem
+                return oldItem.first == newItem.first
             }
 
             override fun areContentsTheSame(
-                oldItem: ProductPostItem,
-                newItem: ProductPostItem
+                oldItem: Pair<String,ProductPostItem>,
+                newItem: Pair<String,ProductPostItem>
             ): Boolean {
                 return oldItem == newItem
             }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
@@ -13,8 +13,10 @@ import com.mbj.ssassamarket.data.model.UserType
 import com.mbj.ssassamarket.databinding.FragmentHomeProductBinding
 import com.mbj.ssassamarket.ui.BaseFragment
 import com.mbj.ssassamarket.ui.common.ProductClickListener
+import com.mbj.ssassamarket.util.Constants
 import com.mbj.ssassamarket.util.Constants.KEY_HOME_PRODUCT
 import com.mbj.ssassamarket.util.EventObserver
+import com.mbj.ssassamarket.util.ProgressDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -24,13 +26,72 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
     override val layoutId: Int get() = R.layout.fragment_home_product
 
     private val viewModel: HomeViewModel by viewModels()
+    private var progressDialog: ProgressDialogFragment? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
+        setupViews()
         setAdapter()
+        observeRefreshResponse()
+        observeRefreshSuccess()
+        observeRefreshCompletion()
+    }
+
+    private fun setupViews() {
+        setupSwipeRefreshLayout()
         setupSpinner()
         observeSearchText()
+    }
+
+    private fun setupSwipeRefreshLayout() {
+        binding.homeSrl.setOnRefreshListener {
+            viewModel.refreshData()
+            binding.homeSrl.isRefreshing = false
+        }
+    }
+
+    private fun setupSpinner() {
+        binding.homeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                val filter = when (position) {
+                    0 -> FilterType.LATEST
+                    1 -> FilterType.PRICE
+                    else -> FilterType.FAVORITE
+                }
+                viewModel.updateFilterType(filter)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        }
+    }
+
+    private fun observeSearchText() {
+        viewModel.searchText.observe(viewLifecycleOwner) {
+            viewModel.updateSearchText()
+        }
+    }
+
+    private fun observeRefreshResponse() {
+        viewModel.itemRefreshResponse.observe(viewLifecycleOwner, EventObserver { response ->
+            viewModel.handleUpdateResponse(response)
+        })
+    }
+
+    private fun observeRefreshSuccess() {
+        viewModel.itemRefreshSuccess.observe(viewLifecycleOwner, EventObserver { success ->
+            // Handle refresh success if needed
+        })
+    }
+
+    private fun observeRefreshCompletion() {
+        viewModel.itemRefreshCompleted.observe(viewLifecycleOwner, EventObserver { completed ->
+            if (completed) {
+                dismissLoadingDialog()
+            } else {
+                showLoadingDialog()
+            }
+        })
     }
 
     private fun setAdapter() {
@@ -45,33 +106,6 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
         }
     }
 
-    private fun setupSpinner() {
-        binding.homeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(
-                parent: AdapterView<*>?,
-                view: View?,
-                position: Int,
-                id: Long
-            ) {
-                val filter = when (position) {
-                    0 -> FilterType.LATEST
-                    1 -> FilterType.PRICE
-                    else -> FilterType.FAVORITE
-                }
-                viewModel.updateFilterType(filter)
-            }
-
-            override fun onNothingSelected(parent: AdapterView<*>?) {
-            }
-        }
-    }
-
-    private fun observeSearchText() {
-        viewModel.searchText.observe(viewLifecycleOwner) {
-            viewModel.updateSearchText()
-        }
-    }
-
     override fun onProductClick(productPostItem: Pair<String,ProductPostItem>) {
         viewModel.navigateBasedOnUserType(productPostItem.second.id) { userType ->
             when (userType) {
@@ -83,6 +117,16 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
                 }
             }
         }
+    }
+
+    private fun showLoadingDialog() {
+        progressDialog = ProgressDialogFragment()
+        progressDialog?.show(childFragmentManager, Constants.PROGRESS_DIALOG)
+    }
+
+    private fun dismissLoadingDialog() {
+        progressDialog?.dismiss()
+        progressDialog = null
     }
 
     companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
@@ -72,11 +72,11 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
         }
     }
 
-    override fun onProductClick(productPostItem: ProductPostItem) {
-        viewModel.navigateBasedOnUserType(productPostItem.id) { userType ->
+    override fun onProductClick(productPostItem: Pair<String,ProductPostItem>) {
+        viewModel.navigateBasedOnUserType(productPostItem.second.id) { userType ->
             when (userType) {
                 UserType.SELLER -> {
-                    val action = HomeFragmentDirections.actionNavigationHomeToSellerFragment(productPostItem)
+                    val action = HomeFragmentDirections.actionNavigationHomeToSellerFragment(productPostItem.first, productPostItem.second)
                     findNavController().navigate(action)
                 }
                 UserType.BUYER -> {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
@@ -27,6 +27,15 @@ class HomeViewModel @Inject constructor(private val productRepository: ProductRe
     val category: LiveData<Category>
         get() = _category
 
+    private val _itemRefreshCompleted = MutableLiveData<Event<Boolean>>()
+    val itemRefreshCompleted: LiveData<Event<Boolean>> get() = _itemRefreshCompleted
+
+    private val _itemRefreshSuccess = MutableLiveData<Event<Boolean>>()
+    val itemRefreshSuccess: LiveData<Event<Boolean>> get() = _itemRefreshSuccess
+
+    private val _itemRefreshResponse = MutableLiveData<Event<Boolean>>()
+    val itemRefreshResponse: LiveData<Event<Boolean>> get() = _itemRefreshResponse
+
     val searchText = MutableLiveData<String>()
 
     private val productList = MediatorLiveData<List<Pair<String, ProductPostItem>>>()
@@ -115,5 +124,28 @@ class HomeViewModel @Inject constructor(private val productRepository: ProductRe
 
             callback(userType)
         }
+    }
+
+    fun refreshData() {
+        viewModelScope.launch {
+            _itemRefreshCompleted.value = Event(false)
+            val products = productRepository.getProduct()
+            if (products != null) {
+                _itemRefreshResponse.value = Event(true)
+                productList.value = products
+                applyFilters()
+            } else {
+                _itemRefreshResponse.value = Event(false)
+            }
+        }
+    }
+
+    fun handleUpdateResponse(response: Boolean) {
+        if (response) {
+            _itemRefreshSuccess.value = Event(true)
+        } else {
+            _itemRefreshSuccess.value = Event(true)
+        }
+        _itemRefreshCompleted.value = Event(true)
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
@@ -15,8 +15,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(private val productRepository: ProductRepository, private val userInfoRepository: UserInfoRepository) : ViewModel() {
 
-    private val _items = MutableLiveData<Event<List<ProductPostItem>>>()
-    val items: LiveData<Event<List<ProductPostItem>>>
+    private val _items = MutableLiveData<Event<List<Pair<String, ProductPostItem>>>>()
+    val items: LiveData<Event<List<Pair<String, ProductPostItem>>>>
         get() = _items
 
     private val _filterType = MutableLiveData<FilterType>()
@@ -29,7 +29,7 @@ class HomeViewModel @Inject constructor(private val productRepository: ProductRe
 
     val searchText = MutableLiveData<String>()
 
-    private val productList = MediatorLiveData<List<ProductPostItem>>()
+    private val productList = MediatorLiveData<List<Pair<String, ProductPostItem>>>()
 
     init {
         loadAllProducts()
@@ -90,7 +90,7 @@ class HomeViewModel @Inject constructor(private val productRepository: ProductRe
             return
         }
 
-        val filteredProducts = productList.value.orEmpty().filter { product ->
+        val filteredProducts = productList.value.orEmpty().filter { (_, product) ->
             product.category == currentCategory.label &&
                     (currentSearchText.isNullOrBlank() || product.title.contains(
                         currentSearchText,
@@ -99,9 +99,9 @@ class HomeViewModel @Inject constructor(private val productRepository: ProductRe
         }.toMutableList()
 
         when (currentFilterType) {
-            FilterType.LATEST -> filteredProducts.sortByDescending { product -> product.createdDate }
-            FilterType.PRICE -> filteredProducts.sortBy { product -> product.price }
-            FilterType.FAVORITE -> filteredProducts.sortByDescending { product -> product.favoriteCount }
+            FilterType.LATEST -> filteredProducts.sortByDescending { (_, product) -> product.createdDate }
+            FilterType.PRICE -> filteredProducts.sortBy { (_, product) -> product.price }
+            FilterType.FAVORITE -> filteredProducts.sortByDescending { (_, product) -> product.favoriteCount }
         }
 
         _items.value = Event(filteredProducts)

--- a/app/src/main/java/com/mbj/ssassamarket/ui/writing/WritingFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/writing/WritingFragment.kt
@@ -43,6 +43,7 @@ import net.daum.mf.map.api.MapReverseGeoCoder
 
 @AndroidEntryPoint
 class WritingFragment : BaseFragment(), LocationManager.LocationUpdateListener {
+
     override val binding get() = _binding as FragmentWritingBinding
     override val layoutId: Int get() = R.layout.fragment_writing
 

--- a/app/src/main/res/layout/fragment_home_product.xml
+++ b/app/src/main/res/layout/fragment_home_product.xml
@@ -35,16 +35,23 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/home_product_rv"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/home_srl"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="15dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/home_spinner" />
+            app:layout_constraintTop_toBottomOf="@id/home_spinner">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/home_product_rv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -34,7 +34,7 @@
     <fragment
         android:id="@+id/navigation_home"
         android:name="com.mbj.ssassamarket.ui.home.HomeFragment"
-        android:label="HomeFragment" >
+        android:label="HomeFragment">
         <action
             android:id="@+id/action_navigation_home_to_sellerFragment"
             app:destination="@id/sellerFragment" />
@@ -78,7 +78,10 @@
     <fragment
         android:id="@+id/sellerFragment"
         android:name="com.mbj.ssassamarket.ui.detail.seller.SellerFragment"
-        android:label="SellerFragment" >
+        android:label="SellerFragment">
+        <argument
+            android:name="postId"
+            app:argType="string" />
         <argument
             android:name="product"
             app:argType="com.mbj.ssassamarket.data.model.ProductPostItem" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,6 @@
     <string name="confirmation_dialog_message_edit">정말로 수정을 취소하시겠습니까??</string>
     <string name="confirmation_dialog_message_cancel">정말로 수정을 하시겠습니까??</string>
     <string name="confirmation_dialog_title">"재확인"</string>
+    <string name="product_update_failed">"상품 업데이트에 실패하셨습니다."</string>
+    <string name="product_update_success">"상품을 업데이트 하셨습니다."</string>
 </resources>


### PR DESCRIPTION

# 상품 목록 가져오는 네트워크 통신 함수 변경

- 반환 타입 변경: List<Pair<String, ProductPostItem>> (상품 목록을 가져오는 네트워크 통신 함수의 반환 타입을 변경하여 postId 값을 포함시킴)

# 상품 정보 업데이트를 위한 네트워크 통신 함수 구현

- 판매자가 상품 정보(title, price, content)를 업데이트할 수 있는 네트워크 통신 함수를 구현함.

# 홈 화면에 상품 데이터 갱신을 위한 SwipeRefreshLayout 적용

- 홈 화면 레이아웃에 SwipeRefreshLayout을 추가
==> 사용자가 스와이프 동작을 수행할 때 홈 화면 로직을 업데이트하여 새로고침 동작을 처리하고 최신 상품 데이터를 DB에서 가져오도록 함

