### PR TITLE
[Feat/buyer favorite] 구매자 상품 상세화면 좋아요 기능 구현 및 일부 로직 수정

### DIFF
--- a/app/src/main/java/com/mbj/ssassamarket/data/model/ProductPostItem.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/model/ProductPostItem.kt
@@ -43,3 +43,8 @@ data class PatchBuyRequest(
     val soldOut: Boolean,
     val shoppingList: List<String?>?
 )
+
+data class FavoriteCountRequest(
+    val favoriteCount: Int,
+    val favoriteList: List<String?>?
+)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -1,10 +1,7 @@
 package com.mbj.ssassamarket.data.source
 
 import android.util.Log
-import com.mbj.ssassamarket.data.model.ImageContent
-import com.mbj.ssassamarket.data.model.PatchBuyRequest
-import com.mbj.ssassamarket.data.model.PatchProductRequest
-import com.mbj.ssassamarket.data.model.ProductPostItem
+import com.mbj.ssassamarket.data.model.*
 import com.mbj.ssassamarket.data.source.remote.MarketNetworkDataSource
 import javax.inject.Inject
 
@@ -64,7 +61,6 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
     suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean {
         return try {
             marketNetworkDataSource.updateProduct(postId, request)
-            true
         } catch (e: Exception) {
             Log.e(TAG, "상품 업데이트 오류", e)
             false

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -49,6 +49,15 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
         }
     }
 
+    suspend fun getProductDetail(postId: String): ProductPostItem? {
+        return try {
+            marketNetworkDataSource.getProductDetail(postId)
+        } catch (e: Exception) {
+            Log.e(TAG, "상세 Product 가져 오던 중 에외가 발생하였습니다.", e)
+            throw Exception("상세 Product 가져 오던 중 에외가 발생하였습니다.  $e")
+        }
+    }
+
     suspend fun getAvailableProducts() : List<Pair<String, ProductPostItem>> {
         return try {
             marketNetworkDataSource.getProduct().filter { (_, product) -> product.soldOut.not() }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -67,6 +67,15 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
         }
     }
 
+    suspend fun updateProductFavorite(postId: String, request: FavoriteCountRequest): Boolean {
+        return try {
+            marketNetworkDataSource.updateProductFavorite(postId, request)
+        } catch (e: Exception) {
+            Log.e(TAG, "좋아요 업데이트 오류", e)
+            false
+        }
+    }
+
     suspend fun buyProduct(postId: String, request: PatchBuyRequest): Boolean {
         return try {
             marketNetworkDataSource.buyProduct(postId, request)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -56,5 +56,11 @@ interface ApiClient {
         @Body requestBody: FavoriteCountRequest,
         @Query("auth") auth: String
     ): Response<Unit>
+
+    @GET("posts/{postId}.json")
+    suspend fun getProductDetail(
+        @Path("postId") postId: String,
+        @Query("auth") auth: String
+    ): Response<ProductPostItem>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/ApiClient.kt
@@ -1,9 +1,6 @@
 package com.mbj.ssassamarket.data.source.remote
 
-import com.mbj.ssassamarket.data.model.PatchBuyRequest
-import com.mbj.ssassamarket.data.model.PatchProductRequest
-import com.mbj.ssassamarket.data.model.ProductPostItem
-import com.mbj.ssassamarket.data.model.User
+import com.mbj.ssassamarket.data.model.*
 import retrofit2.Response
 import retrofit2.http.*
 
@@ -50,6 +47,13 @@ interface ApiClient {
     suspend fun buyProduct(
         @Path("postId") postId: String,
         @Body request: PatchBuyRequest,
+        @Query("auth") auth: String
+    ): Response<Unit>
+
+    @PATCH("posts/{postId}.json")
+    suspend fun updateProductFavorite(
+        @Path("postId") productId: String,
+        @Body requestBody: FavoriteCountRequest,
         @Query("auth") auth: String
     ): Response<Unit>
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -301,20 +301,23 @@ class FirebaseDataSource @Inject constructor(
         return null
     }
 
-    override suspend fun updateProduct(postId: String, request: PatchProductRequest) {
+    override suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean {
         val (user, idToken) = getUserAndIdToken()
         if (idToken != null) {
             try {
                 val response = apiClient.updateProduct(postId, request, idToken)
                 if (response.isSuccessful) {
                     Log.d(TAG, "상품 업데이트 성공")
+                    return true
                 } else {
                     Log.e(TAG, "상품 업데이트 실패 (Status Code: ${response.code()})")
+                    return false
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "상품 업데이트 오류", e)
             }
         }
+        return false
     }
 
     override suspend fun buyProduct(postId: String, request: PatchBuyRequest) {

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -265,6 +265,28 @@ class FirebaseDataSource @Inject constructor(
         }
     }
 
+    override suspend fun getProductDetail(postId: String): ProductPostItem? {
+        val (user, idToken) = getUserAndIdToken()
+        return try {
+            if (idToken != null) {
+                val response = apiClient.getProductDetail(postId, idToken)
+                if (response.isSuccessful) {
+                    val product = response.body()
+                    product
+                } else {
+                    val statusCode = response.code()
+                    Log.e(TAG, "Failed to get product detail. Status Code: $statusCode")
+                    throw Exception("Failed to get product detail. Status Code: $statusCode")
+                }
+            } else {
+                throw Exception("Missing GoogleIdToken")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception while getting product detail", e)
+            throw Exception("Failed to get product detail", e)
+        }
+    }
+
     override suspend fun getUserAndIdToken(): Pair<FirebaseUser?, String?> {
         val user = FirebaseAuth.getInstance().currentUser
         var idToken: String? = null

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -320,6 +320,25 @@ class FirebaseDataSource @Inject constructor(
         return false
     }
 
+    override suspend fun updateProductFavorite(postId: String, request: FavoriteCountRequest): Boolean {
+        val (user, idToken) = getUserAndIdToken()
+        if (idToken != null) {
+            try {
+                val response = apiClient.updateProductFavorite(postId, request, idToken)
+                if (response.isSuccessful) {
+                    Log.d(TAG, "좋아요 업데이트 성공")
+                    return true
+                } else {
+                    Log.e(TAG, "좋아요 업데이트 (Status Code: ${response.code()})")
+                    return false
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "좋아요 업데이트", e)
+            }
+        }
+        return false
+    }
+
     override suspend fun buyProduct(postId: String, request: PatchBuyRequest) {
         val (user, idToken) = getUserAndIdToken()
         if (idToken != null) {

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -6,6 +6,7 @@ import com.google.firebase.database.ValueEventListener
 import com.mbj.ssassamarket.data.model.*
 
 interface MarketNetworkDataSource {
+
     suspend fun currentUserExists(): Boolean
     suspend fun addUser(nickname: String): Boolean
     suspend fun checkDuplicateUserName(nickname: String): Boolean
@@ -26,8 +27,8 @@ interface MarketNetworkDataSource {
     suspend fun updateMyLatLng(latLng: String): Boolean
     suspend fun getProduct(): List<Pair<String, ProductPostItem>>
     suspend fun getProductDetail(postId: String): ProductPostItem?
-    suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
-    suspend fun getUserNameByUserId(userIdToken: String) : String?
+    suspend fun getUserAndIdToken(): Pair<FirebaseUser?, String?>
+    suspend fun getUserNameByUserId(userIdToken: String): String?
     suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean
     suspend fun updateProductFavorite(postId: String, request: FavoriteCountRequest): Boolean
     suspend fun buyProduct(postId: String, request: PatchBuyRequest)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -25,6 +25,7 @@ interface MarketNetworkDataSource {
     suspend fun getMyDataId(): String?
     suspend fun updateMyLatLng(latLng: String): Boolean
     suspend fun getProduct(): List<Pair<String, ProductPostItem>>
+    suspend fun getProductDetail(postId: String): ProductPostItem?
     suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
     suspend fun getUserNameByUserId(userIdToken: String) : String?
     suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -27,7 +27,7 @@ interface MarketNetworkDataSource {
     suspend fun getProduct(): List<Pair<String, ProductPostItem>>
     suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
     suspend fun getUserNameByUserId(userIdToken: String) : String?
-    suspend fun updateProduct(postId: String, request: PatchProductRequest)
+    suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean
     suspend fun buyProduct(postId: String, request: PatchBuyRequest)
     suspend fun enterChatRoom(productId: String, otherUserName: String, otherLocation: String): String
     suspend fun getMyUserItem(callback: (User) -> Unit)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -28,6 +28,7 @@ interface MarketNetworkDataSource {
     suspend fun getUserAndIdToken() : Pair<FirebaseUser?, String?>
     suspend fun getUserNameByUserId(userIdToken: String) : String?
     suspend fun updateProduct(postId: String, request: PatchProductRequest): Boolean
+    suspend fun updateProductFavorite(postId: String, request: FavoriteCountRequest): Boolean
     suspend fun buyProduct(postId: String, request: PatchBuyRequest)
     suspend fun enterChatRoom(productId: String, otherUserName: String, otherLocation: String): String
     suspend fun getMyUserItem(callback: (User) -> Unit)

--- a/app/src/main/java/com/mbj/ssassamarket/ui/bindings/ImageViewBindings.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/bindings/ImageViewBindings.kt
@@ -31,3 +31,10 @@ fun ImageView.loadFirstImage(imageLocations: List<String?>?) {
         this.load(R.drawable.null_icon)
     }
 }
+
+@BindingAdapter("imageUrl")
+fun ImageView.loadImage(imageUrl: String) {
+    this.load(imageUrl) {
+        error(R.drawable.null_icon)
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/ui/common/ProductDetailInfoLayout.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/common/ProductDetailInfoLayout.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.databinding.ViewProductDetailInfoBinding
+import com.mbj.ssassamarket.util.DateFormat.getFormattedElapsedTime
 
 
 class ProductDetailInfoLayout (context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
@@ -27,7 +28,7 @@ class ProductDetailInfoLayout (context: Context, attrs: AttributeSet) : Constrai
                     val timeTextColor = getColor(R.styleable.ProductDetailInfoLayout_detailTimeTextColor, 0)
                     val nicknameText = getString(R.styleable.ProductDetailInfoLayout_detailNicknameText)
                     val timeText = getString(R.styleable.ProductDetailInfoLayout_detailTimeText)
-                    val locationText = getString(R.styleable.ProductDetailInfoLayout_detailLocation)
+                    val locationText = getString(R.styleable.ProductDetailInfoLayout_detailLocationText)
                     val titleTextColor = getColor(R.styleable.ProductDetailInfoLayout_detailTimeTextColor, 0)
                     val priceTextColor = getColor(R.styleable.ProductDetailInfoLayout_detailTimeTextColor, 0)
                     val contentTextColor = getColor(R.styleable.ProductDetailInfoLayout_detailTimeTextColor, 0)
@@ -41,7 +42,7 @@ class ProductDetailInfoLayout (context: Context, attrs: AttributeSet) : Constrai
                     setDetailTimeTextColor(timeTextColor)
                     setDetailNicknameText(nicknameText)
                     setDetailTimeText(timeText)
-                    setLocation(locationText)
+                    setDetailLocationText(locationText)
                     setDetailTitleTextColor(titleTextColor)
                     setDetailPriceTextColor(priceTextColor)
                     setDetailContentTextColor(contentTextColor)
@@ -86,13 +87,13 @@ class ProductDetailInfoLayout (context: Context, attrs: AttributeSet) : Constrai
     }
 
     fun setDetailTimeText(text: CharSequence?) {
-        binding.detailTimeTv.setText(text)
+        val formattedText = text?.toString()?.let { getFormattedElapsedTime(it) }
+        binding.detailTimeTv.text = formattedText
     }
 
-    fun setLocation(text: CharSequence?) {
+    fun setDetailLocationText(text: CharSequence?) {
         binding.detailLocationTv.setText(text)
     }
-
     fun setDetailTitleTextChangeListener(textWatcher: TextWatcher) {
         binding.detailTitleTiev.addTextChangedListener(textWatcher)
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/BannerAdapter.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/BannerAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
 import com.mbj.ssassamarket.databinding.RecyclerviewItemBannerBinding
 
 class BannerAdapter : ListAdapter<String, BannerAdapter.BannerViewHolder>(BannerDiffCallback()) {
@@ -21,7 +20,7 @@ class BannerAdapter : ListAdapter<String, BannerAdapter.BannerViewHolder>(Banner
     class BannerViewHolder(private val binding: RecyclerviewItemBannerBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(image: String) {
-            binding.bannerIv.load(image)
+            binding.imageUrl = image
         }
 
         companion object {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerFragment.kt
@@ -44,9 +44,7 @@ class BuyerFragment : BaseFragment() {
             val coarseLocationGranted =
                 permissions[Manifest.permission.ACCESS_COARSE_LOCATION] ?: false
 
-            if (fineLocationGranted || coarseLocationGranted) {
-                onLocationPermissionGranted()
-            } else {
+            if (!(fineLocationGranted || coarseLocationGranted)) {
                 showPermissionPermanentlyDeniedDialog()
             }
         }
@@ -160,16 +158,9 @@ class BuyerFragment : BaseFragment() {
         startActivity(intent)
     }
 
-    private fun onLocationPermissionGranted() {
-        viewModel.onChatButtonClicked(
-            getString(R.string.test_seller_name),
-            getString(R.string.test_seller_location)
-        )
-    }
-
     private fun onBuyerChatButtonClicked() {
         if (locationManager.isAnyLocationPermissionGranted()) {
-            onLocationPermissionGranted()
+            viewModel.onChatButtonClicked()
         } else {
             requestLocationPermission()
         }
@@ -177,7 +168,7 @@ class BuyerFragment : BaseFragment() {
 
     private fun onBuyerBuyButtonClicked() {
         if (locationManager.isAnyLocationPermissionGranted()) {
-            onLocationPermissionGranted()
+            viewModel.onBuyButtonClicked()
         } else {
             requestLocationPermission()
         }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerViewModel.kt
@@ -81,7 +81,7 @@ class BuyerViewModel @Inject constructor(
         }
     }
 
-    fun likeProduct() {
+    private fun likeProduct() {
         viewModelScope.launch {
             _productFavoriteCompleted.value = Event(false)
 
@@ -102,7 +102,7 @@ class BuyerViewModel @Inject constructor(
         }
     }
 
-    fun unlikeProduct() {
+    private fun unlikeProduct() {
         viewModelScope.launch {
             _productFavoriteCompleted.value = Event(false)
 
@@ -120,6 +120,14 @@ class BuyerViewModel @Inject constructor(
                 _productFavoriteResponse.value = Event(productRepository.updateProductFavorite(postId!!, request))
                 toggleIsLiked()
             }
+        }
+    }
+
+    fun onHeartClicked() {
+        if (isLiked.value?.peekContent() == true) {
+            unlikeProduct()
+        } else {
+            likeProduct()
         }
     }
 

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerViewModel.kt
@@ -66,18 +66,33 @@ class BuyerViewModel @Inject constructor(
         }
     }
 
-    fun onChatButtonClicked(otherUserName: String, otherLocation: String) {
-        val patchRequest = PatchBuyRequest(true, listOf(productPostItem?.id))
+    fun onChatButtonClicked() {
+        viewModelScope.launch {
+            if (nickname.value?.peekContent() != null && productPostItem?.location != null) {
+                _chatRoomId.value = Event(
+                    chatRepository.enterChatRoom(
+                        otherUserId.value?.peekContent()!!,
+                        nickname.value!!.peekContent()!!,
+                        productPostItem?.location!!
+                    )
+                )
+            }
+        }
+    }
 
+    fun onBuyButtonClicked() {
+        val patchRequest = PatchBuyRequest(true, listOf(productPostItem?.id))
         viewModelScope.launch {
             postId?.let { productRepository.buyProduct(it, patchRequest) }
-            _chatRoomId.value = Event(
-                chatRepository.enterChatRoom(
-                    otherUserId.value?.peekContent()!!,
-                    otherUserName,
-                    otherLocation
+            if (nickname.value?.peekContent() != null && productPostItem?.location != null) {
+                _chatRoomId.value = Event(
+                    chatRepository.enterChatRoom(
+                        otherUserId.value?.peekContent()!!,
+                        nickname.value!!.peekContent()!!,
+                        productPostItem?.location!!
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
@@ -156,9 +156,9 @@ class SellerFragment : BaseFragment() {
             setDetailPriceEnabled(isEditMode)
             setDetailTitleEnabled(isEditMode)
             setDetailTitleText(product?.peekContent()?.title)
-            setDetailTimeText(product?.peekContent()?.createdDate?.let { getFormattedElapsedTime(it) })
+            setDetailTimeText(product?.peekContent()?.createdDate)
             setDetailPriceText(product?.peekContent()?.price.toString())
-            setLocation(product?.peekContent()?.location)
+            setDetailLocationText(product?.peekContent()?.location)
             setDetailContentText(product?.peekContent()?.content)
             if (editMode == EditMode.READ_ONLY) {
                 setDetailContentTextColor(ContextCompat.getColor(context, R.color.black))

--- a/app/src/main/res/layout/fragment_buyer.xml
+++ b/app/src/main/res/layout/fragment_buyer.xml
@@ -36,6 +36,7 @@
                         app:srcCompat="@drawable/back_icon" />
 
                     <ImageView
+                        android:id="@+id/detail_heart"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_buyer.xml
+++ b/app/src/main/res/layout/fragment_buyer.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.mbj.ssassamarket.ui.detail.buyer.BuyerViewModel" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -39,6 +42,8 @@
                         android:id="@+id/detail_heart"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:onClick="@{() -> viewModel.onHeartClicked()}"
+                        android:src="@{viewModel.isLiked.peekContent() ? @drawable/heart_full_icon : @drawable/heart_empty_icon}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="@id/guideline_vertical_93"
                         app:layout_constraintTop_toTopOf="parent"
@@ -91,8 +96,14 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:detailContentEnabled="false"
+                    app:detailContentText="@{viewModel.productPostItem.content}"
+                    app:detailLocationText="@{viewModel.productPostItem.location}"
+                    app:detailNicknameText="@{viewModel.nickname.peekContent()}"
                     app:detailPriceEnabled="false"
+                    app:detailPriceText="@{Integer.toString(viewModel.productPostItem.price)}"
+                    app:detailTimeText="@{viewModel.productPostItem.createdDate}"
                     app:detailTitleEnabled="false"
+                    app:detailTitleText="@{viewModel.productPostItem.title}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/recyclerview_item_banner.xml
+++ b/app/src/main/res/layout/recyclerview_item_banner.xml
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ImageView
-        android:id="@+id/banner_iv"
-        android:layout_width="@dimen/viewpager_item_width"
-        android:layout_height="0dp"
-        android:layout_marginStart="@dimen/viewpager_item_margin"
-        android:scaleType="centerCrop"
-        app:layout_constraintDimensionRatio="h, 2:1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <variable
+            name="imageUrl"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/banner_iv"
+            android:layout_width="@dimen/viewpager_item_width"
+            android:layout_height="0dp"
+            android:layout_marginStart="@dimen/viewpager_item_margin"
+            android:scaleType="centerCrop"
+            app:imageUrl="@{imageUrl}"
+            app:layout_constraintDimensionRatio="h, 2:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -10,7 +10,7 @@
         <attr name="detailTimeTextColor" format="color" />
         <attr name="detailNicknameText" format="string" />
         <attr name="detailTimeText" format="string" />
-        <attr name="detailLocation" format="string" />
+        <attr name="detailLocationText" format="string" />
         <attr name="detailTitleTextColor" format="color" />
         <attr name="detailPriceTextColor" format="color" />
         <attr name="detailContentTextColor" format="color" />


### PR DESCRIPTION
# 해당 상품에 대한 좋아요 기능 구현

- updateProductFavorite() 함수로 상품의 좋아요 관련 업데이트를 처리하는 네트워크 함수 구현
	- DB의 상품 객체의 favoriteCount와 favoriteList 필드를 업데이트하여 로직 구현
- getProductDetail() 함수로 해당 상품을 가져오는 네트워크 함수 구현
- 상품에 대한 좋아요 기능 구현

# BuyerFragment에 데이터 바인딩 적용

- BuyerFragment에 데이터 바인딩 적용

# 채팅하기와 구매하기에 대해 기능별로 다른 로직을 구현
- 채팅하기와 구매하기에 대해 기능별로 다른 로직 구현
	- 채팅하기와 구매하기는 채팅방 입장 로직은 공통이지만, 구매하기는 추가로 DB의 soldOut와 shoppingList 업데이트

# 기타
- updateProduct() 함수의 추상화 인터페이스 반환값 타입을 Boolean으로 설정