### PR TITLE
[Feat/home offline] 홈 화면 오프라인 대응 및 앱 전체적으로 네트워크 예외처리 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,4 +121,9 @@ dependencies {
 
     //SwipeRefreshLayout 관련
     implementation ("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+
+    //Room 관련
+    implementation ("androidx.room:room-ktx:2.5.2")
+    implementation ("androidx.room:room-runtime:2.5.2")
+    kapt ("androidx.room:room-compiler:2.5.2")
 }

--- a/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
@@ -1,8 +1,18 @@
 package com.mbj.ssassamarket
 
 import android.app.Application
+import com.mbj.ssassamarket.data.source.local.AppDatabase
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class SsaSsaMarketApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        appDatabase = AppDatabase.create(applicationContext)
+    }
+
+    companion object {
+        lateinit var appDatabase: AppDatabase
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/SsaSsaMarketApplication.kt
@@ -1,18 +1,7 @@
 package com.mbj.ssassamarket
 
 import android.app.Application
-import com.mbj.ssassamarket.data.source.local.AppDatabase
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class SsaSsaMarketApplication : Application() {
-
-    override fun onCreate() {
-        super.onCreate()
-        appDatabase = AppDatabase.create(applicationContext)
-    }
-
-    companion object {
-        lateinit var appDatabase: AppDatabase
-    }
-}
+class SsaSsaMarketApplication : Application()

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -1,12 +1,17 @@
 package com.mbj.ssassamarket.data.source
 
 import com.mbj.ssassamarket.data.model.*
+import com.mbj.ssassamarket.data.source.local.MarketDatabaseDataSource
+import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
 import com.mbj.ssassamarket.data.source.remote.MarketNetworkDataSource
 import com.mbj.ssassamarket.data.source.remote.network.ApiResponse
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class ProductRepository @Inject constructor(private val marketNetworkDataSource: MarketNetworkDataSource) {
+class ProductRepository @Inject constructor(
+    private val marketNetworkDataSource: MarketNetworkDataSource,
+    private val marketDatabaseDataSource: MarketDatabaseDataSource
+) {
 
     fun addProductPost(
         onComplete: () -> Unit,
@@ -84,5 +89,13 @@ class ProductRepository @Inject constructor(private val marketNetworkDataSource:
         request: FavoriteCountRequest
     ): Flow<ApiResponse<Unit>> {
         return marketNetworkDataSource.updateProductFavorite(onComplete, onError, postId, request)
+    }
+
+    suspend fun insertProducts(products: List<ProductEntity>) {
+        marketDatabaseDataSource.insertProducts(products)
+    }
+
+    fun getAllProducts(): Flow<List<ProductEntity>> {
+        return marketDatabaseDataSource.getAllProducts()
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
@@ -1,23 +1,12 @@
 package com.mbj.ssassamarket.data.source.local
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.mbj.ssassamarket.data.source.local.dao.ProductDao
 import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
 
-@Database(entities = [ProductEntity::class], version = 1)
+@Database(entities = [ProductEntity::class], version = 2)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun productDao(): ProductDao
-
-    companion object {
-        fun create(context: Context): AppDatabase {
-            return Room.databaseBuilder(
-                context,
-                AppDatabase::class.java, "ssassa_database"
-            ).build()
-        }
-    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
@@ -1,0 +1,23 @@
+package com.mbj.ssassamarket.data.source.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.mbj.ssassamarket.data.source.local.dao.ProductDao
+import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
+
+@Database(entities = [ProductEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun productDao(): ProductDao
+
+    companion object {
+        fun create(context: Context): AppDatabase {
+            return Room.databaseBuilder(
+                context,
+                AppDatabase::class.java, "ssassa_database"
+            ).build()
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/AppDatabase.kt
@@ -2,10 +2,12 @@ package com.mbj.ssassamarket.data.source.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.mbj.ssassamarket.data.source.local.dao.ProductDao
 import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
 
 @Database(entities = [ProductEntity::class], version = 2)
+@TypeConverters(ProductTypeConverters::class)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun productDao(): ProductDao

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/MarketDatabaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/MarketDatabaseDataSource.kt
@@ -1,0 +1,11 @@
+package com.mbj.ssassamarket.data.source.local
+
+import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
+import kotlinx.coroutines.flow.Flow
+
+interface MarketDatabaseDataSource {
+
+    suspend fun insertProducts(products: List<ProductEntity>)
+
+    fun getAllProducts(): Flow<List<ProductEntity>>
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
@@ -1,0 +1,16 @@
+package com.mbj.ssassamarket.data.source.local
+
+import androidx.room.TypeConverter
+
+class ProductTypeConverters {
+
+    @TypeConverter
+    fun fromStringList(list: List<String>?): String {
+        return list?.joinToString(",") ?: ""
+    }
+
+    @TypeConverter
+    fun toStringList(value: String): List<String> {
+        return value.split(",")
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/RoomDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/RoomDataSource.kt
@@ -2,11 +2,12 @@ package com.mbj.ssassamarket.data.source.local
 
 import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
-class RoomDataSource(private val appDatabase: AppDatabase) : MarketDatabaseDataSource {
+class RoomDataSource @Inject constructor(private val appDatabase: AppDatabase) : MarketDatabaseDataSource {
 
     override suspend fun insertProducts(products: List<ProductEntity>) {
-        appDatabase.productDao().insertProducts(products)
+        return appDatabase.productDao().insertProducts(products)
     }
 
     override fun getAllProducts(): Flow<List<ProductEntity>> {

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/RoomDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/RoomDataSource.kt
@@ -1,0 +1,15 @@
+package com.mbj.ssassamarket.data.source.local
+
+import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
+import kotlinx.coroutines.flow.Flow
+
+class RoomDataSource(private val appDatabase: AppDatabase) : MarketDatabaseDataSource {
+
+    override suspend fun insertProducts(products: List<ProductEntity>) {
+        appDatabase.productDao().insertProducts(products)
+    }
+
+    override fun getAllProducts(): Flow<List<ProductEntity>> {
+        return appDatabase.productDao().getAllProducts()
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/dao/ProductDao.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/dao/ProductDao.kt
@@ -1,0 +1,18 @@
+package com.mbj.ssassamarket.data.source.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.mbj.ssassamarket.data.source.local.entities.ProductEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ProductDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertProducts(products: List<ProductEntity>)
+
+    @Query("SELECT * FROM products")
+    fun getAllProducts(): Flow<List<ProductEntity>>
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
@@ -1,0 +1,36 @@
+package com.mbj.ssassamarket.data.source.local.entities
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "products")
+data class ProductEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "product_id")
+    val id: String,
+    @ColumnInfo(name = "product_content")
+    val content: String,
+    @ColumnInfo(name = "product_created_date")
+    val createdDate: String,
+    @ColumnInfo(name = "product_image_locations")
+    val imageLocations: List<String?>?,
+    @ColumnInfo(name = "product_price")
+    val price: Int,
+    @ColumnInfo(name = "product_title")
+    val title: String,
+    @ColumnInfo(name = "product_category")
+    val category: String,
+    @ColumnInfo(name = "product_sold_out")
+    val soldOut: Boolean,
+    @ColumnInfo(name = "product_favorite_count")
+    val favoriteCount: Int,
+    @ColumnInfo(name = "product_shopping_list")
+    val shoppingList: List<String?>?,
+    @ColumnInfo(name = "product_location")
+    val location: String,
+    @ColumnInfo(name = "product_lat_lng")
+    val latLng: String,
+    @ColumnInfo(name = "product_favorite_list")
+    val favoriteList: List<String?>?
+)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
@@ -9,6 +9,8 @@ data class ProductEntity(
     @PrimaryKey
     @ColumnInfo(name = "product_id")
     val id: String,
+    @ColumnInfo(name = "user_id")
+    val uid: String,
     @ColumnInfo(name = "product_content")
     val content: String,
     @ColumnInfo(name = "product_created_date")

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/entities/ProductEntity.kt
@@ -3,6 +3,7 @@ package com.mbj.ssassamarket.data.source.local.entities
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.mbj.ssassamarket.data.model.ProductPostItem
 
 @Entity(tableName = "products")
 data class ProductEntity(
@@ -36,3 +37,21 @@ data class ProductEntity(
     @ColumnInfo(name = "product_favorite_list")
     val favoriteList: List<String?>?
 )
+
+fun ProductEntity.toProductPostItem(): ProductPostItem {
+    return ProductPostItem(
+        id = this.uid,
+        content = this.content,
+        createdDate = this.createdDate,
+        imageLocations = this.imageLocations,
+        price = this.price,
+        title = this.title,
+        category = this.category,
+        soldOut = this.soldOut,
+        favoriteCount = this.favoriteCount,
+        shoppingList = this.shoppingList,
+        location = this.location,
+        latLng = this.latLng,
+        favoriteList = this.favoriteList
+    )
+}

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -156,17 +156,21 @@ class FirebaseDataSource @Inject constructor(
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<Map<String, ProductPostItem>>> = flow {
-        val (user, idToken) = getUserAndIdToken()
-        val googleIdToken = idToken ?: ""
-        val response = apiClient.getProduct(googleIdToken)
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.getProduct(googleIdToken)
 
-        response.onSuccess {
-            emit(response)
-            onComplete()
-        }.onError { code, message ->
-            onError("code: $code, message: $message")
-        }.onException { throwable ->
-            onError(throwable.message)
+            response.onSuccess {
+                emit(response)
+                onComplete()
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException { throwable ->
+                onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
         }
     }.flowOn(defaultDispatcher)
 

--- a/app/src/main/java/com/mbj/ssassamarket/di/DatabaseModule.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/di/DatabaseModule.kt
@@ -1,0 +1,32 @@
+package com.mbj.ssassamarket.di
+
+import android.content.Context
+import androidx.room.Room
+import com.mbj.ssassamarket.data.source.local.AppDatabase
+import com.mbj.ssassamarket.data.source.local.MarketDatabaseDataSource
+import com.mbj.ssassamarket.data.source.local.RoomDataSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java, "ssassa_database"
+        ).fallbackToDestructiveMigration().build()
+    }
+
+    @Provides
+    fun provideMarketDatabaseDataSource(appDatabase: AppDatabase): MarketDatabaseDataSource {
+        return RoomDataSource(appDatabase)
+    }
+}

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
@@ -3,6 +3,7 @@ package com.mbj.ssassamarket.ui.home
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -92,8 +93,19 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
                         adapter.submitList(productList)
                     }
                 }
+                launch {
+                    viewModel.isError.collectLatest { isError ->
+                        if (isError) {
+                            showToast(R.string.error_message_product_get)
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private fun showToast(messageResId: Int) {
+        Toast.makeText(requireContext(), messageResId, Toast.LENGTH_SHORT).show()
     }
 
     override fun onProductClick(productPostItem: Pair<String, ProductPostItem>) {

--- a/app/src/main/res/layout/fragment_home_product.xml
+++ b/app/src/main/res/layout/fragment_home_product.xml
@@ -44,16 +44,6 @@
             app:layout_constraintTop_toTopOf="parent"
             app:visible="@{viewModel.isLoading}" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/error_message_product_get"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:visible="@{viewModel.isError}" />
-
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/home_srl"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_splash_fragement.xml
+++ b/app/src/main/res/layout/fragment_splash_fragement.xml
@@ -27,15 +27,5 @@
             app:lottie_loop="true"
             app:lottie_rawRes="@raw/splash_animation" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/error_message_retry"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:visible="@{viewModel.isError}" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,4 +80,5 @@
     <string name="request_writing_image">상품 사진을 등록해주세요.</string>
     <string name="request_writing_all">글의 내용들을 작성해주세요.</string>
     <string name="request_edit_product">변경된 내용이 없습니다.</string>
+    <string name="error_network">네트워크 상태를 확인해주세요.</string>
 </resources>


### PR DESCRIPTION
# 상품 데이터 관련 Room DB 구현
- Room 라이브러리 사용을 위한 의존성 추가
- Room을 사용한 상품 데이터 저장 및 불러오기 기능 구현
- Hilt 사용하여 의존성 주입 적용

- TypeConverter 인터페이스를 구현하여 문자열 리스트를 Room에서 사용 가능한 형태로 변환하는 기능 구현
- Room DB에 Pair 타입을 저장을 할 수 없어 네트워크 통신 함수로부터 가져온 전체 상품 데이터 타입인 List<Pair<String, ProductPostItem> 형식의 데이터를 List<ProductEntity>의 타입을 변환하는 함수 구현
- Room DB로 부터 상품 정보를 List<ProductEntity> 타입으로 가져온 것을 UI를 관리하는 변수 타입인  List<Pair<String, ProductPostItem> 형식의 타입을 변환하는 함수 구현

# 홈 화면 오프라인 대응 및 네트워크 통신 오류 대응
- 홈 화면의 오프라인 대응 및 네트워크 통신 오류를 대응하기 위해 Room을 활용하여 상품 데이터를 로컬 데이터베이스에 저장하고 불러오는 기능 구현

# 스플래시 화면 오프라인 대응 및 네트워크 통신 오류 대응
- 스플래시 화면의 오프라인 대응 및 네트워크 통신 오류를 대응하기 위해 예외 발생 시 로그인 화면으로 이동하도록 구현

# 앱 전체적으로 네트워크 연결 예외 처리
- 앱 전체적으로 네트워크 연결 예외 처리를 위한 try-catch 블록 추가