### PR TITLE
[Feat/products sync issue] 상품 목록들 동기화 이슈 해결

### DIFF
--- a/app/src/main/java/com/mbj/ssassamarket/ui/bindings/ImageViewBindings.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/bindings/ImageViewBindings.kt
@@ -25,6 +25,8 @@ fun ImageView.loadFirstImage(imageLocations: List<String?>?) {
     if (firstImageLocation != null) {
         val roundedCorners = RoundedCornersTransformation(15f)
         this.load(firstImageLocation.toString()) {
+            crossfade(true)
+            crossfade(1000)
             transformations(roundedCorners)
             error(R.drawable.null_icon)
         }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeProductFragment.kt
@@ -40,6 +40,7 @@ class HomeProductFragment : BaseFragment(), ProductClickListener {
     }
 
     private fun setupViews() {
+        viewModel.loadAllProducts()
         setupSwipeRefreshLayout()
         setupSpinner()
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/home/HomeViewModel.kt
@@ -42,15 +42,12 @@ class HomeViewModel @Inject constructor(
 
     private val productList = MutableStateFlow<List<Pair<String, ProductPostItem>>>(emptyList())
 
-    init {
-        loadAllProducts()
-    }
-
-    private fun loadAllProducts() {
+    fun loadAllProducts() {
+        _isLoading.value = true
+        _isError.value = false
         viewModelScope.launch {
-            _isError.value = false
             productRepository.getProduct(
-                onComplete = { _isLoading.value = false },
+                onComplete = { },
                 onError =
                 {
                     _isError.value = true
@@ -63,6 +60,7 @@ class HomeViewModel @Inject constructor(
                     val productEntities = convertToProductEntities(updatedProducts)
                     productRepository.insertProducts(productEntities)
                     productList.value = updatedProducts
+                    _isLoading.value = false
                     setupProductList()
                 }
             }
@@ -75,7 +73,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun updateProductsFromRoomDatabase() {
+    private fun updateProductsFromRoomDatabase() {
         viewModelScope.launch {
             productRepository.getAllProducts().collectLatest { newProductList ->
                 val updatedProductList = newProductList.toTransformedList()

--- a/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryFragment.kt
@@ -30,7 +30,6 @@ class InventoryFragment : BaseFragment(), ProductClickListener {
         binding.viewModel = viewModel
         binding.inventoryOuterRv.adapter = adapter
         viewModel.getMyNickname()
-        viewModel.initProductPostItemList()
 
         observeInventoryDataList(adapter)
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryFragment.kt
@@ -37,7 +37,18 @@ class InventoryFragment : BaseFragment(), ProductClickListener {
 
     private fun observeInventoryDataList(adapter: InventoryOuterAdapter) {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.inventoryDataList.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED).collectLatest { inventoryDataList ->
+            viewModel.productPostItemList.flowWithLifecycle(
+                viewLifecycleOwner.lifecycle,
+                Lifecycle.State.STARTED
+            ).collectLatest { productPostItemList ->
+                val myFavoriteProducts = viewModel.getMyFavoriteProduct(productPostItemList)
+                val myRegisteredProducts = viewModel.getMyRegisteredProduct(productPostItemList)
+                val myPurchasedProducts = viewModel.getMyPurchasedProduct(productPostItemList)
+                val inventoryDataList = viewModel.createInventoryDataList(
+                    myFavoriteProducts,
+                    myRegisteredProducts,
+                    myPurchasedProducts
+                )
                 adapter.submitList(inventoryDataList)
             }
         }
@@ -47,11 +58,19 @@ class InventoryFragment : BaseFragment(), ProductClickListener {
         viewModel.navigateBasedOnUserType(productPostItem.second.id) { userType ->
             when (userType) {
                 UserType.SELLER -> {
-                    val action = InventoryFragmentDirections.actionNavigationInventoryToSellerFragment(productPostItem.first, productPostItem.second)
+                    val action =
+                        InventoryFragmentDirections.actionNavigationInventoryToSellerFragment(
+                            productPostItem.first,
+                            productPostItem.second
+                        )
                     findNavController().navigate(action)
                 }
                 UserType.BUYER -> {
-                    val action = InventoryFragmentDirections.actionNavigationInventoryToBuyerFragment(productPostItem.first, productPostItem.second)
+                    val action =
+                        InventoryFragmentDirections.actionNavigationInventoryToBuyerFragment(
+                            productPostItem.first,
+                            productPostItem.second
+                        )
                     findNavController().navigate(action)
                 }
             }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryOuterAdapter.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryOuterAdapter.kt
@@ -52,6 +52,7 @@ class InventoryOuterAdapter(private val productClickListener: ProductClickListen
     }
 
     fun submitList(list: List<InventoryData>) {
+        inventoryDataList.clear()
         inventoryDataList.addAll(list)
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/inventory/InventoryViewModel.kt
@@ -37,7 +37,7 @@ class InventoryViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             productRepository.getProduct(
-                onComplete = { },
+                onComplete = {_isLoading.value = false },
                 onError = {
                     _isLoading.value = false
                     _productError.value = true
@@ -45,6 +45,7 @@ class InventoryViewModel @Inject constructor(
             ).collectLatest { productMap ->
                 if (productMap is ApiResultSuccess) {
                     val updateProduct = updateProductsWithImageUrls(productMap.data)
+                    _isLoading.value = false
                     _productPostItemList.value = updateProduct
                 }
             }
@@ -93,7 +94,6 @@ class InventoryViewModel @Inject constructor(
             inventoryDataList.add(InventoryData.ProductType(InventoryType.SHOPPING_PRODUCT))
             inventoryDataList.add(InventoryData.ProductItem(myPurchasedProducts))
         }
-        _isLoading.value = false
         return inventoryDataList
     }
 

--- a/app/src/main/res/layout/recyclerview_item_banner.xml
+++ b/app/src/main/res/layout/recyclerview_item_banner.xml
@@ -16,12 +16,12 @@
         <ImageView
             android:id="@+id/banner_iv"
             android:layout_width="@dimen/viewpager_item_width"
-            android:layout_height="0dp"
+            android:layout_height="@dimen/viewpager_item_width"
             android:scaleType="centerCrop"
             app:imageUrl="@{imageUrl}"
-            app:layout_constraintDimensionRatio="h, 1:1.5"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintDimensionRatio="h, 1:1.1"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,6 +4,6 @@
     <dimen name="material_divider_height">0.7dp</dimen>
     <dimen name="writing_form">40dp</dimen>
     <dimen name="detail_product_top_margin">10dp</dimen>
-    <dimen name="viewpager_item_width">270dp</dimen>
+    <dimen name="viewpager_item_width">280dp</dimen>
     <dimen name="viewpager_item_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
# 상품 목록들 동기화 이슈 해결
- 인벤토리 화면에서 상세화면으로 들어가서 물품의 상태를 변경 후 인벤토리 화면으로 돌아올 때 동기화 문제 해결

- 홈 화면에서 상세화면 또는 등록화면 이동 후 물품 수정 또는 물품 등록 시 동기화되지 않던 문제 해결
- 로딩 변수를 상품 동기화 고려하여 설정
- 인벤토리 화면의 데이터를 가지고 오는것을 담당하는 initProductPostItemList() 반환 타입 변경 - Flow를 반환하여 StateFlow로 변환 하여 productPostItemList 변수에 적용

# 기타 수정
- ViewPager 배너 이미지 사이즈 조정
- 상품 목록들을 보여주는 ImageView 로딩에 1초 동안의 페이드 효과 추가