### PR TITLE
[Feat/viewmodel stateflow conversion] ViewModel의 상태 변수를 Flow를 반환하는 함수로부터 StateFlow로 변환하여 사용

### DIFF
--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
@@ -8,19 +8,17 @@ import com.squareup.moshi.Types
 
 class ProductTypeConverters {
 
-    private val moshi = Moshi.Builder().build()
+    private val moshi: Moshi = Moshi.Builder().build()
+    private val type = Types.newParameterizedType(List::class.java, String::class.java)
+    private val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
 
     @TypeConverter
     fun fromStringList(list: List<String>?): String {
-        val type = Types.newParameterizedType(List::class.java, String::class.java)
-        val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
         return jsonAdapter.toJson(list)
     }
 
     @TypeConverter
     fun toStringList(value: String): List<String>? {
-        val type = Types.newParameterizedType(List::class.java, String::class.java)
-        val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
         return try {
             jsonAdapter.fromJson(value)
         } catch (e: JsonDataException) {

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/local/ProductTypeConverters.kt
@@ -1,16 +1,30 @@
 package com.mbj.ssassamarket.data.source.local
 
 import androidx.room.TypeConverter
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 
 class ProductTypeConverters {
 
+    private val moshi = Moshi.Builder().build()
+
     @TypeConverter
     fun fromStringList(list: List<String>?): String {
-        return list?.joinToString(",") ?: ""
+        val type = Types.newParameterizedType(List::class.java, String::class.java)
+        val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
+        return jsonAdapter.toJson(list)
     }
 
     @TypeConverter
-    fun toStringList(value: String): List<String> {
-        return value.split(",")
+    fun toStringList(value: String): List<String>? {
+        val type = Types.newParameterizedType(List::class.java, String::class.java)
+        val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
+        return try {
+            jsonAdapter.fromJson(value)
+        } catch (e: JsonDataException) {
+            null
+        }
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/buyer/BuyerFragment.kt
@@ -72,7 +72,6 @@ class BuyerFragment : BaseFragment() {
     private fun setupViewModel() {
         viewModel.setOtherUserId(args.product.id)
         viewModel.initializeProduct(args.postId, args.product)
-        viewModel.getProductNickname()
         viewModel.checkProductInFavorites()
     }
 

--- a/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/detail/seller/SellerFragment.kt
@@ -41,7 +41,6 @@ class SellerFragment : BaseFragment() {
 
     private fun initViewModel() {
         viewModel.initializeProduct(args.postId, args.product)
-        viewModel.getProductNickname()
     }
 
     private fun setupViewPager() {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/launcher/SplashFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/launcher/SplashFragment.kt
@@ -28,7 +28,6 @@ class SplashFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-        viewModel.checkCurrentUserExists()
         checkNetworkThenNavigate()
     }
 
@@ -50,7 +49,7 @@ class SplashFragment : BaseFragment() {
         findNavController().navigate(action)
     }
 
-    fun checkNetworkThenNavigate() {
+    private fun checkNetworkThenNavigate() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {

--- a/app/src/main/java/com/mbj/ssassamarket/ui/writing/WritingFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/writing/WritingFragment.kt
@@ -63,7 +63,6 @@ class WritingFragment : BaseFragment(), LocationManager.LocationUpdateListener, 
 
     private val viewModel: WritingViewModel by viewModels()
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeGalleryLauncher()
@@ -77,7 +76,6 @@ class WritingFragment : BaseFragment(), LocationManager.LocationUpdateListener, 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-        viewModel.getMyDataId()
         setupCategorySpinner()
         setupAdapters()
         setupRecyclerView()


### PR DESCRIPTION
## ViewModel의 상태 변수의 값들 중 MutableStateFlow를 이용하는 목적인 .value를 통해 ViewModel 내에서 값을 재할당 하는것이 아니라고 하면 함수 타입을 Flow 타입으로 바꾸고 해당하는 함수를 가지고 stateIn() 함수를 사용하여 Flow -> StateFlow 타입으로 변경하여 사용하도록 함
- WritingViewModel의 dataId 상태 관리 변수
- SplashViewModel의 isAccountExistsOnServer 상태 관리 변수
- SellerViewModel의 nickname 상태 관리 변수
- BuyerViewModel의 nickname 상태 관리 변수

## 기타 수정
- Project의 일관성을 위해 네트워크 통신에서도 Moshi 라이브러리를 사용했던 것처럼 Room에서도 일관되게 Moshi 라이브러리를 사용하여 JSON 직렬화/역직렬화 하도록 변경함

