### PR TITLE
[Feat/user membership withdrawal] 회원 탈퇴 기능 구현 

### DIFF
--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
@@ -64,11 +64,18 @@ class ChatRepository @Inject constructor(private val marketNetworkDataSource: Ma
         )
     }
 
-    fun getChatRooms(
+    fun getMyChatRooms(
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<List<ChatRoomItem>>> {
-        return marketNetworkDataSource.getChatRooms(onComplete, onError)
+        return marketNetworkDataSource.getMyChatRoom(onComplete, onError)
+    }
+
+    fun getAllChatRoomData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+    ): Flow<ApiResponse<Map<String, Map<String, ChatRoomItem>>>> {
+        return marketNetworkDataSource.getAllChatRoomData(onComplete, onError)
     }
 
     fun addChatDetailEventListener(

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
@@ -102,6 +102,14 @@ class ChatRepository @Inject constructor(private val marketNetworkDataSource: Ma
         return marketNetworkDataSource.deleteMyInfoFromChatRoomsForOtherUser(onComplete, onError, otherUid, myUid)
     }
 
+    fun deleteChatMessageByChatRoomId(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        chatRoomId: String,
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.deleteChatMessageByChatRoomId(onComplete, onError, chatRoomId)
+    }
+
     fun removeChatDetailEventListener(
         chatDetailEventListener: ChildEventListener?,
         chatRoomId: String

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
@@ -78,6 +78,14 @@ class ChatRepository @Inject constructor(private val marketNetworkDataSource: Ma
         return marketNetworkDataSource.getAllChatRoomData(onComplete, onError)
     }
 
+    fun deleteChatRoomsDataForMyUid(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        uid: String
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.deleteChatRoomsDataForMyUid(onComplete, onError, uid)
+    }
+
     fun addChatDetailEventListener(
         chatRoomId: String,
         onChatItemAdded: (ChatItem) -> Unit

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ChatRepository.kt
@@ -93,6 +93,15 @@ class ChatRepository @Inject constructor(private val marketNetworkDataSource: Ma
         return marketNetworkDataSource.addChatDetailEventListener(chatRoomId, onChatItemAdded)
     }
 
+    fun deleteMyInfoFromChatRoomsForOtherUser(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        otherUid: String,
+        myUid: String,
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.deleteMyInfoFromChatRoomsForOtherUser(onComplete, onError, otherUid, myUid)
+    }
+
     fun removeChatDetailEventListener(
         chatDetailEventListener: ChildEventListener?,
         chatRoomId: String

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/ProductRepository.kt
@@ -98,4 +98,12 @@ class ProductRepository @Inject constructor(
     fun getAllProducts(): Flow<List<ProductEntity>> {
         return marketDatabaseDataSource.getAllProducts()
     }
+
+    fun deleteProductData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        postUid: String
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.deleteProductData(onComplete, onError, postUid)
+    }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
@@ -41,6 +41,13 @@ class UserInfoRepository @Inject constructor(private val marketNetworkDataSource
         return marketNetworkDataSource.logout(onComplete, onError)
     }
 
+    fun deleteUserData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        uid: String
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.deleteUserData(onComplete, onError, uid)
+    }
 
     suspend fun getUserAndIdToken(): Pair<FirebaseUser?, String?> {
         return marketNetworkDataSource.getUserAndIdToken()

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -518,6 +518,30 @@ class FirebaseDataSource @Inject constructor(
         onComplete()
     }.flowOn(defaultDispatcher)
 
+    override fun deleteProductData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        postUid: String
+    ): Flow<ApiResponse<Unit>> = flow<ApiResponse<Unit>> {
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.deleteProductData(postUid, googleIdToken)
+
+            response.onSuccess {
+                emit(ApiResultSuccess(Unit))
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException { throwable ->
+                onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
     override fun addChatDetailEventListener(
         chatRoomId: String,
         onChatItemAdded: (ChatItem) -> Unit

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -614,6 +614,30 @@ class FirebaseDataSource @Inject constructor(
         onComplete()
     }.flowOn(defaultDispatcher)
 
+    override fun deleteChatMessageByChatRoomId(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        chatRoomId: String
+    ): Flow<ApiResponse<Unit>> = flow<ApiResponse<Unit>> {
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.deleteChatMessageByChatRoomId(chatRoomId, googleIdToken)
+
+            response.onSuccess {
+                emit(ApiResultSuccess(Unit))
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException { throwable ->
+                onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
     override fun addChatDetailEventListener(
         chatRoomId: String,
         onChatItemAdded: (ChatItem) -> Unit

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -445,7 +445,7 @@ class FirebaseDataSource @Inject constructor(
         onComplete()
     }.flowOn(defaultDispatcher)
 
-    override fun getChatRooms(
+    override fun getMyChatRoom(
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<List<ChatRoomItem>>> = flow<ApiResponse<List<ChatRoomItem>>> {
@@ -534,6 +534,29 @@ class FirebaseDataSource @Inject constructor(
                 onError("code: $code, message: $message")
             }.onException { throwable ->
                 onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
+    override fun getAllChatRoomData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<Map<String, Map<String, ChatRoomItem>>>> = flow {
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.getAllChatRoomData(googleIdToken)
+
+            response.onSuccess {
+                emit(response)
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException {
+                onError(it.message)
             }
         } catch (e: Exception) {
             onError(e.message)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -589,6 +589,31 @@ class FirebaseDataSource @Inject constructor(
         onComplete()
     }.flowOn(defaultDispatcher)
 
+    override fun deleteMyInfoFromChatRoomsForOtherUser(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        otherUid: String,
+        myUid: String
+    ): Flow<ApiResponse<Unit>> = flow<ApiResponse<Unit>> {
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.deleteMyInfoFromChatRoomsForOtherUser(otherUid, myUid, googleIdToken)
+
+            response.onSuccess {
+                emit(ApiResultSuccess(Unit))
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException { throwable ->
+                onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
     override fun addChatDetailEventListener(
         chatRoomId: String,
         onChatItemAdded: (ChatItem) -> Unit

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/FirebaseDataSource.kt
@@ -565,6 +565,30 @@ class FirebaseDataSource @Inject constructor(
         onComplete()
     }.flowOn(defaultDispatcher)
 
+    override fun deleteChatRoomsDataForMyUid(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        uid: String
+    ): Flow<ApiResponse<Unit>> = flow<ApiResponse<Unit>> {
+        try {
+            val (user, idToken) = getUserAndIdToken()
+            val googleIdToken = idToken ?: ""
+            val response = apiClient.deleteChatRoomsDataForMyUid(uid, googleIdToken)
+
+            response.onSuccess {
+                emit(ApiResultSuccess(Unit))
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException { throwable ->
+                onError(throwable.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
     override fun addChatDetailEventListener(
         chatRoomId: String,
         onChatItemAdded: (ChatItem) -> Unit

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -118,6 +118,12 @@ interface MarketNetworkDataSource {
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<Unit>>
 
+    fun deleteUserData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        uid: String
+    ): Flow<ApiResponse<Unit>>
+
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener
 
     fun removeChatDetailEventListener(chatDetailEventListener: ChildEventListener?, chatRoomId: String)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -124,6 +124,12 @@ interface MarketNetworkDataSource {
         uid: String
     ): Flow<ApiResponse<Unit>>
 
+    fun deleteProductData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        postUid: String
+    ): Flow<ApiResponse<Unit>>
+
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener
 
     fun removeChatDetailEventListener(chatDetailEventListener: ChildEventListener?, chatRoomId: String)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -108,7 +108,7 @@ interface MarketNetworkDataSource {
         dataId: String,
     ): Flow<ApiResponse<Unit>>
 
-    fun getChatRooms(
+    fun getMyChatRoom(
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<List<ChatRoomItem>>>
@@ -129,6 +129,11 @@ interface MarketNetworkDataSource {
         onError: (message: String?) -> Unit,
         postUid: String
     ): Flow<ApiResponse<Unit>>
+
+    fun getAllChatRoomData(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+    ): Flow<ApiResponse<Map<String, Map<String, ChatRoomItem>>>>
 
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -6,6 +6,8 @@ import com.google.firebase.database.ValueEventListener
 import com.mbj.ssassamarket.data.model.*
 import com.mbj.ssassamarket.data.source.remote.network.ApiResponse
 import kotlinx.coroutines.flow.Flow
+import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface MarketNetworkDataSource {
 
@@ -139,6 +141,13 @@ interface MarketNetworkDataSource {
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit,
         uid: String
+    ): Flow<ApiResponse<Unit>>
+
+    fun deleteMyInfoFromChatRoomsForOtherUser(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        otherUid: String,
+        myUid: String,
     ): Flow<ApiResponse<Unit>>
 
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -6,8 +6,6 @@ import com.google.firebase.database.ValueEventListener
 import com.mbj.ssassamarket.data.model.*
 import com.mbj.ssassamarket.data.source.remote.network.ApiResponse
 import kotlinx.coroutines.flow.Flow
-import retrofit2.http.Path
-import retrofit2.http.Query
 
 interface MarketNetworkDataSource {
 
@@ -148,6 +146,12 @@ interface MarketNetworkDataSource {
         onError: (message: String?) -> Unit,
         otherUid: String,
         myUid: String,
+    ): Flow<ApiResponse<Unit>>
+
+    fun deleteChatMessageByChatRoomId(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        chatRoomId: String,
     ): Flow<ApiResponse<Unit>>
 
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -135,6 +135,12 @@ interface MarketNetworkDataSource {
         onError: (message: String?) -> Unit,
     ): Flow<ApiResponse<Map<String, Map<String, ChatRoomItem>>>>
 
+    fun deleteChatRoomsDataForMyUid(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        uid: String
+    ): Flow<ApiResponse<Unit>>
+
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener
 
     fun removeChatDetailEventListener(chatDetailEventListener: ChildEventListener?, chatRoomId: String)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -85,5 +85,12 @@ interface ApiClient {
         @Path("uid") uid: String,
         @Query("auth") auth: String
     ): ApiResponse<Unit>
+
+    @DELETE("chatRooms/{otherUid}/{myUid}.json")
+    suspend fun deleteMyInfoFromChatRoomsForOtherUser(
+        @Path("otherUid") otherUid: String,
+        @Path("myUid") myUid: String,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -92,5 +92,11 @@ interface ApiClient {
         @Path("myUid") myUid: String,
         @Query("auth") auth: String
     ): ApiResponse<Unit>
+
+    @DELETE("chats/{chatRoomId}.json")
+    suspend fun deleteChatMessageByChatRoomId(
+        @Path("chatRoomId") chatRoomId: String,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -74,5 +74,10 @@ interface ApiClient {
         @Path("postId") postId: String,
         @Query("auth") auth: String
     ): ApiResponse<Unit>
+
+    @GET("chatRooms.json")
+    suspend fun getAllChatRoomData(
+        @Query("auth") auth: String
+    ): ApiResponse<Map<String, Map<String, ChatRoomItem>>>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -62,5 +62,11 @@ interface ApiClient {
         @Path("postId") postId: String,
         @Query("auth") auth: String
     ): ApiResponse<ProductPostItem>
+
+    @DELETE("user/{uid}.json")
+    suspend fun deleteUserData(
+        @Path("uid") uid: String,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -79,5 +79,11 @@ interface ApiClient {
     suspend fun getAllChatRoomData(
         @Query("auth") auth: String
     ): ApiResponse<Map<String, Map<String, ChatRoomItem>>>
+
+    @DELETE("chatRooms/{uid}.json")
+    suspend fun deleteChatRoomsDataForMyUid(
+        @Path("uid") uid: String,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -68,5 +68,11 @@ interface ApiClient {
         @Path("uid") uid: String,
         @Query("auth") auth: String
     ): ApiResponse<Unit>
+
+    @DELETE("posts/{postId}.json")
+    suspend fun deleteProductData(
+        @Path("postId") postId: String,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/ui/chat/detail/ChatDetailFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/chat/detail/ChatDetailFragment.kt
@@ -91,8 +91,9 @@ class ChatDetailFragment : BaseFragment(), LocationManager.LocationUpdateListene
 
         binding.chatDetailSendIv.setOnClickListener {
             val message = binding.chatDetailTiev.text.toString()
-            if (message.isEmpty()) {
+            if (message.isNullOrBlank()) {
                 showToast(R.string.empty_message_error)
+                binding.chatDetailTiev.text?.clear()
                 return@setOnClickListener
             }
             viewModel.sendMessage(message, viewModel.myDataId.value)

--- a/app/src/main/java/com/mbj/ssassamarket/ui/chat/list/ChatListViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/chat/list/ChatListViewModel.kt
@@ -47,7 +47,7 @@ class ChatListViewModel @Inject constructor(private val chatRepository: ChatRepo
 
     fun getChatRooms() {
         viewModelScope.launch {
-            chatRepository.getChatRooms(
+            chatRepository.getMyChatRooms(
                 onComplete = { _isLoading.value = false },
                 onError = { _chatRoomsError.value = true }
             ).collectLatest { chatRoomList ->

--- a/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingFragment.kt
@@ -29,6 +29,7 @@ class SettingFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         observeLogoutSuccess()
+        observeMembershipWithdrawalSuccess()
 
         binding.settingLogoutTv.setOnClickListener {
             showLogoutConfirmationDialog()
@@ -36,12 +37,25 @@ class SettingFragment : BaseFragment() {
         binding.settingFeedbackTv.setOnClickListener {
             openGoogleFeedbackForm()
         }
+        binding.settingMembershipWithdrawalTv.setOnClickListener {
+            showMembershipWithdrawalConfirmationDialog()
+        }
     }
 
     private fun observeLogoutSuccess() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.isLogoutSuccess.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED).collectLatest { isLogoutSuccess ->
                 if (isLogoutSuccess) {
+                    navigateToLoginFragment()
+                }
+            }
+        }
+    }
+
+    private fun observeMembershipWithdrawalSuccess() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.isMembershipWithdrawalSuccess.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED).collectLatest { isMembershipWithdrawalSuccess ->
+                if (isMembershipWithdrawalSuccess) {
                     navigateToLoginFragment()
                 }
             }
@@ -66,6 +80,22 @@ class SettingFragment : BaseFragment() {
         builder.setPositiveButton(getString(R.string.confirm)) { dialog, _ ->
             dialog.dismiss()
             viewModel.onLogoutButtonClicked()
+        }
+        builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
+            dialog.dismiss()
+        }
+
+        val dialog = builder.create()
+        dialog.show()
+    }
+
+    private fun showMembershipWithdrawalConfirmationDialog() {
+        val builder = MaterialAlertDialogBuilder(requireContext())
+        builder.setMessage(getString(R.string.request_membership_withdrawal))
+
+        builder.setPositiveButton(getString(R.string.confirm)) { dialog, _ ->
+            dialog.dismiss()
+            viewModel.onMembershipWithdrawalClicked()
         }
         builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
             dialog.dismiss()

--- a/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingFragment.kt
@@ -14,6 +14,8 @@ import com.mbj.ssassamarket.BuildConfig
 import com.mbj.ssassamarket.R
 import com.mbj.ssassamarket.databinding.FragmentSettingBinding
 import com.mbj.ssassamarket.ui.BaseFragment
+import com.mbj.ssassamarket.util.Constants
+import com.mbj.ssassamarket.util.ProgressDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -24,12 +26,14 @@ class SettingFragment : BaseFragment() {
     override val layoutId: Int get() = R.layout.fragment_setting
 
     private val viewModel: SettingViewModel by viewModels()
+    private var progressDialog: ProgressDialogFragment? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         observeLogoutSuccess()
         observeMembershipWithdrawalSuccess()
+        observeIsMembershipWithdrawalCompleted()
 
         binding.settingLogoutTv.setOnClickListener {
             showLogoutConfirmationDialog()
@@ -57,6 +61,18 @@ class SettingFragment : BaseFragment() {
             viewModel.isMembershipWithdrawalSuccess.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED).collectLatest { isMembershipWithdrawalSuccess ->
                 if (isMembershipWithdrawalSuccess) {
                     navigateToLoginFragment()
+                }
+            }
+        }
+    }
+
+    private fun observeIsMembershipWithdrawalCompleted() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.isMembershipWithdrawalCompleted.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED).collectLatest { isMembershipWithdrawalCompleted ->
+                if (isMembershipWithdrawalCompleted == true) {
+                    hideLoadingDialog()
+                } else if (isMembershipWithdrawalCompleted == false) {
+                    showLoadingDialog()
                 }
             }
         }
@@ -103,5 +119,15 @@ class SettingFragment : BaseFragment() {
 
         val dialog = builder.create()
         dialog.show()
+    }
+
+    private fun showLoadingDialog() {
+        progressDialog = ProgressDialogFragment()
+        progressDialog?.show(childFragmentManager, Constants.PROGRESS_DIALOG)
+    }
+
+    private fun hideLoadingDialog() {
+        progressDialog?.dismiss()
+        progressDialog = null
     }
 }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingViewModel.kt
@@ -36,6 +36,9 @@ class SettingViewModel @Inject constructor(
     private val _isMembershipWithdrawalError = MutableStateFlow(false)
     val isMembershipWithdrawalError: StateFlow<Boolean> = _isMembershipWithdrawalError
 
+    private val _isMembershipWithdrawalCompleted = MutableStateFlow<Boolean?>(null)
+    val isMembershipWithdrawalCompleted: StateFlow<Boolean?> = _isMembershipWithdrawalCompleted
+
     private var myUid: String? = null
 
     init {
@@ -65,6 +68,7 @@ class SettingViewModel @Inject constructor(
     fun onMembershipWithdrawalClicked() {
         viewModelScope.launch {
             _isLoading.value = true
+            _isMembershipWithdrawalCompleted.value = false
             deleteChatRoomData()
             deleteProductData()
             performLogout()
@@ -81,6 +85,7 @@ class SettingViewModel @Inject constructor(
                 myUid!!
             ).collectLatest { response ->
                 if (response is ApiResultSuccess) {
+                    _isMembershipWithdrawalCompleted.value = true
                     _isMembershipWithdrawalSuccess.value = true
                 }
             }

--- a/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/setting/SettingViewModel.kt
@@ -2,6 +2,9 @@ package com.mbj.ssassamarket.ui.setting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mbj.ssassamarket.data.model.ChatRoomItem
+import com.mbj.ssassamarket.data.source.ChatRepository
+import com.mbj.ssassamarket.data.source.ProductRepository
 import com.mbj.ssassamarket.data.source.UserInfoRepository
 import com.mbj.ssassamarket.data.source.remote.network.ApiResultSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +15,11 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingViewModel @Inject constructor(private val userInfoRepository: UserInfoRepository) : ViewModel() {
+class SettingViewModel @Inject constructor(
+    private val userInfoRepository: UserInfoRepository,
+    private val productRepository: ProductRepository,
+    private val chatRepository: ChatRepository
+) : ViewModel() {
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
@@ -22,6 +29,18 @@ class SettingViewModel @Inject constructor(private val userInfoRepository: UserI
 
     private val _isLogoutError = MutableStateFlow(false)
     val isLogoutError: StateFlow<Boolean> = _isLogoutError
+
+    private val _isMembershipWithdrawalSuccess = MutableStateFlow(false)
+    val isMembershipWithdrawalSuccess: StateFlow<Boolean> = _isMembershipWithdrawalSuccess
+
+    private val _isMembershipWithdrawalError = MutableStateFlow(false)
+    val isMembershipWithdrawalError: StateFlow<Boolean> = _isMembershipWithdrawalError
+
+    private var myUid: String? = null
+
+    init {
+        getMyUid()
+    }
 
     fun onLogoutButtonClicked() {
         viewModelScope.launch {
@@ -34,6 +53,126 @@ class SettingViewModel @Inject constructor(private val userInfoRepository: UserI
                     _isLogoutSuccess.value = true
                 }
             }
+        }
+    }
+
+    private fun getMyUid() {
+        viewModelScope.launch {
+            myUid = userInfoRepository.getUserAndIdToken().first?.uid
+        }
+    }
+
+    fun onMembershipWithdrawalClicked() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            deleteChatRoomData()
+            deleteProductData()
+            performLogout()
+            deleteUserData()
+        }
+    }
+
+    private suspend fun deleteUserData() {
+        _isLoading.value = true
+        if (myUid != null) {
+            userInfoRepository.deleteUserData(
+                onComplete = { _isLoading.value = false },
+                onError = { _isMembershipWithdrawalError.value = true },
+                myUid!!
+            ).collectLatest { response ->
+                if (response is ApiResultSuccess) {
+                    _isMembershipWithdrawalSuccess.value = true
+                }
+            }
+        }
+    }
+
+    private suspend fun deleteProductData() {
+        _isLoading.value = true
+        productRepository.getProduct(
+            onComplete = { _isLoading.value = false },
+            onError = { _isMembershipWithdrawalError.value = true }
+        ).collectLatest { response ->
+            if (response is ApiResultSuccess) {
+                response.data.forEach { (postId, postData) ->
+                    if (postData.id == myUid) {
+                        _isLoading.value = true
+                        productRepository.deleteProductData(
+                            onComplete = { _isLoading.value = false },
+                            onError = { _isMembershipWithdrawalError.value = true },
+                            postId
+                        ).collectLatest {
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun deleteChatRoomData() {
+        _isLoading.value = true
+        chatRepository.getAllChatRoomData(
+            onComplete = { },
+            onError = { _isMembershipWithdrawalError.value = true },
+        ).collectLatest { response ->
+            if (response is ApiResultSuccess) {
+                response.data.forEach { (uid, chatRoomData) ->
+
+                    if (uid == myUid) {
+                        deleteChatRoomsDataForMyUid(uid)
+                        deleteChatMessagesForChatRooms(chatRoomData.values)
+                    }
+
+                    if (chatRoomData.keys.contains(myUid)) {
+                        chatRoomData.keys.forEach { otherUserUid ->
+                            if (otherUserUid == myUid) {
+                                deleteMyInfoFromChatRoomsForOtherUser(uid, otherUserUid)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun deleteChatRoomsDataForMyUid(uid: String) {
+        chatRepository.deleteChatRoomsDataForMyUid(
+            onComplete = { _isLoading.value = false },
+            onError = { _isMembershipWithdrawalError.value = true },
+            uid
+        ).collectLatest {
+        }
+    }
+
+    private suspend fun deleteMyInfoFromChatRoomsForOtherUser(uid: String, otherUserUid: String) {
+        chatRepository.deleteMyInfoFromChatRoomsForOtherUser(
+            onComplete = { _isLoading.value = false },
+            onError = { _isMembershipWithdrawalError.value = true },
+            uid,
+            otherUserUid
+        ).collectLatest {
+        }
+    }
+
+    private suspend fun deleteChatMessagesForChatRooms(chatRooms: Collection<ChatRoomItem>) {
+        chatRooms.forEach { chatRoomItem ->
+            chatRoomItem.chatRoomId?.let { chatRoomId ->
+                chatRepository.deleteChatMessageByChatRoomId(
+                    onComplete = { _isLoading.value = false },
+                    onError = { _isMembershipWithdrawalError.value = true },
+                    chatRoomId
+                ).collectLatest {
+                }
+            }
+        }
+    }
+
+    private suspend fun performLogout() {
+        _isLoading.value = true
+        userInfoRepository.logout(
+            onComplete = { _isLoading.value = false },
+            onError = { _isLogoutError.value = true }
+        ).collectLatest {
         }
     }
 }

--- a/app/src/main/res/layout/fragment_chat_detail.xml
+++ b/app/src/main/res/layout/fragment_chat_detail.xml
@@ -127,6 +127,7 @@
                 android:background="@null"
                 android:hint="@string/request_message"
                 android:textColor="@color/black"
+                android:textColorHint="@color/grey_300"
                 android:textSize="20sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -83,6 +83,26 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/setting_logout_md" />
 
+        <TextView
+            android:id="@+id/setting_membership_withdrawal_tv"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/membership_withdrawal"
+            android:textSize="23sp"
+            app:layout_constraintBottom_toTopOf="@id/setting_membership_withdrawal_md"
+            app:layout_constraintStart_toStartOf="@id/guideline_horizontal_3"
+            app:layout_constraintTop_toBottomOf="@id/setting_feedback_md" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/setting_membership_withdrawal_md"
+            android:layout_width="0dp"
+            android:layout_height="0.7dp"
+            android:layout_marginTop="70dp"
+            app:dividerColor="@color/grey_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/setting_feedback_md" />
+
 
         <com.mbj.ssassamarket.util.ProgressIndicatorView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -122,6 +122,15 @@
             app:layout_constraintTop_toTopOf="parent"
             app:visible="@{viewModel.isLogoutError}" />
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:visible="@{viewModel.isMembershipWithdrawalError()}" />
+
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline_horizontal_3"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/recyclerview_item_me_chat.xml
+++ b/app/src/main/res/layout/recyclerview_item_me_chat.xml
@@ -20,7 +20,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/chat_me_background"
-            android:maxWidth="300dp"
+            android:maxWidth="220dp"
             android:paddingStart="10dp"
             android:paddingTop="8dp"
             android:paddingEnd="10dp"

--- a/app/src/main/res/layout/recyclerview_item_other_chat.xml
+++ b/app/src/main/res/layout/recyclerview_item_other_chat.xml
@@ -67,7 +67,7 @@
             android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
             android:background="@drawable/chat_other_background"
-            android:maxWidth="250dp"
+            android:maxWidth="220dp"
             android:paddingStart="10dp"
             android:paddingTop="8dp"
             android:paddingEnd="10dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="setting">설정</string>
     <string name="logout">로그아웃</string>
     <string name="customer_feedback">고객 의견</string>
+    <string name="membership_withdrawal">회원 탈퇴</string>
     <string name="request_logout">로그아웃 하시겠습니까?</string>
     <string name="cancel">취소</string>
     <string name="confirm">확인</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="customer_feedback">고객 의견</string>
     <string name="membership_withdrawal">회원 탈퇴</string>
     <string name="request_logout">로그아웃 하시겠습니까?</string>
+    <string name="request_membership_withdrawal">회원 탈퇴 하시겠습니까?</string>
     <string name="cancel">취소</string>
     <string name="confirm">확인</string>
     <string name="request_buy">구매 하시겠습니까?</string>


### PR DESCRIPTION
# 회원 탈퇴 기능 구현
- Firebase Realtime DB의 user Root 객체에서 사용자 계정 정보를 삭제하는 네트워크 함수 구현

- Firebase Realtime DB의 posts Root 객체에서 상품을 삭제하는 네트워크 함수 구현
- Firebase Realtime DB의 chatRooms Root 객체의 모든 데이터를 가져오는 네트워크 함수 구현
- Firebase Realtime DB의 chatRooms Root 객체에서 나의 채팅방 정보를 삭제하는 네트워크 함수 구현
- Firebase Realtime DB의 chatRooms Root 객체에서 상대방 입장에서 나의 채팅방 정보를 삭제하는 네트워크 함수 구현
- Firebase Realtime DB의 chats Root 객체에서 특정 chatRoomId에 해당하는 메세지를 삭제하는 네트워크 함수 구현

==> 구현한 함수를 사용하여 회원 탈퇴 기능 구현

# 기타 수정
- 채팅방 메세지 컷아웃 방지를 위한 maxWidth 값 변경

- 채팅 메세지를 보낼 때 띄어쓰기만 있는 메세지를 빈 메세지로 처리하기 위해 isNullOrBlank()를 사용하여 띄어쓰기 예외 처리를 추가
- 다크모드 대응을 위한 hint 색상 설정
