### PR TITLE
[Feat/fcm token refresh] 앱 실행 후 첫 화면(Splash 화면)에서 FCM 토큰 값 갱신 구현

### DIFF
--- a/app/src/main/java/com/mbj/ssassamarket/data/model/User.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/model/User.kt
@@ -19,3 +19,8 @@ data class PatchUserLatLng(
     @Json(name = "latLng")
     val latLng: String? = null
 )
+
+data class PatchUserFcmToken(
+    @Json(name = "fcmToken")
+    val fcmToken: String? = null
+)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/UserInfoRepository.kt
@@ -49,6 +49,15 @@ class UserInfoRepository @Inject constructor(private val marketNetworkDataSource
         return marketNetworkDataSource.deleteUserData(onComplete, onError, uid)
     }
 
+    fun updateUserFcmToken(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        userId: String,
+        userPostKey: String
+    ): Flow<ApiResponse<Unit>> {
+        return marketNetworkDataSource.updateUserFcmToken(onComplete, onError, userId, userPostKey)
+    }
+
     suspend fun getUserAndIdToken(): Pair<FirebaseUser?, String?> {
         return marketNetworkDataSource.getUserAndIdToken()
     }

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/MarketNetworkDataSource.kt
@@ -154,6 +154,13 @@ interface MarketNetworkDataSource {
         chatRoomId: String,
     ): Flow<ApiResponse<Unit>>
 
+    fun updateUserFcmToken(
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit,
+        userId: String,
+        userPostKey: String
+    ): Flow<ApiResponse<Unit>>
+
     fun addChatDetailEventListener(chatRoomId: String, onChatItemAdded: (ChatItem) -> Unit): ChildEventListener
 
     fun removeChatDetailEventListener(chatDetailEventListener: ChildEventListener?, chatRoomId: String)

--- a/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/data/source/remote/network/ApiClient.kt
@@ -98,5 +98,13 @@ interface ApiClient {
         @Path("chatRoomId") chatRoomId: String,
         @Query("auth") auth: String
     ): ApiResponse<Unit>
+
+    @PATCH("user/{userId}/{userPostKey}.json")
+    suspend fun updateUserFcmToken(
+        @Path("userId") userId: String,
+        @Path("userPostKey") userPostKey: String,
+        @Body requestFcmToken: PatchUserFcmToken,
+        @Query("auth") auth: String
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/mbj/ssassamarket/ui/launcher/SplashFragment.kt
+++ b/app/src/main/java/com/mbj/ssassamarket/ui/launcher/SplashFragment.kt
@@ -64,11 +64,26 @@ class SplashFragment : BaseFragment() {
                 }
                 launch {
                     viewModel.isAccountExistsOnServer.collectLatest { isAccountExistsOnServer ->
-                        delay(2000)
-                        if (isAccountExistsOnServer != null) {
+                        if (isAccountExistsOnServer == true) {
+                            delay(1000)
+                            viewModel.refreshFcmToken()
+                        }
+                        else if(isAccountExistsOnServer == false) {
+                            delay(2000)
                             navigateBasedOnUserState(
                                 viewModel.autoLoginState,
                                 isAccountExistsOnServer,
+                                viewModel.currentUser
+                            )
+                        }
+                    }
+                }
+                launch {
+                    viewModel.isFcmTokenRefreshCompleted.collectLatest { isFcmTokenRefreshCompleted ->
+                        if (isFcmTokenRefreshCompleted) {
+                            navigateBasedOnUserState(
+                                viewModel.autoLoginState,
+                                viewModel.isAccountExistsOnServer.value!!,
                                 viewModel.currentUser
                             )
                         }


### PR DESCRIPTION
# FCM 토큰 값 갱신
- Firebase Realtime DB의 User 루트 객체에서 내 계정 정보 중 fcmToken 데이터를 업데이트 하는 네트워크 함수 구현
- 앱 실행 후 Splash 화면에서 FirebaseAuth의 currentUser의 uid를 확인하여 서버에 해당 계정이 존재하면 FCM 토큰 값을 갱신하는 기능 구현